### PR TITLE
feat(store): add plain-markdown page storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,11 +1259,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1274,7 +1295,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2029,7 +2050,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2139,9 +2160,11 @@ dependencies = [
 name = "gpui-notes"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
  "gpui",
  "gpui_platform",
  "smallvec",
+ "tempfile",
 ]
 
 [[package]]
@@ -4321,6 +4344,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -5694,7 +5728,7 @@ dependencies = [
  "async_zip",
  "collections",
  "command-fds",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "futures",
  "futures-lite 1.13.0",
@@ -6308,7 +6342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6376,7 +6410,7 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6520,7 +6554,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6561,11 +6595,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6579,18 +6622,33 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -6613,15 +6671,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6637,9 +6713,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6649,9 +6737,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6986,7 +7086,7 @@ dependencies = [
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
  "core-text",
- "dirs",
+ "dirs 6.0.0",
  "dwrote",
  "float-ord",
  "freetype-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3
 # components that can have children. uncomment this line or
 # use `cargo add smallvec` to add it to your project
 smallvec = "1.13.2"
+dirs = "5"
 
 [dev-dependencies]
 gpui = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3", features = ["test-support"] }
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ A Rust + [GPUI](https://www.gpui.rs/) note-taking app inspired by [Logseq](https
 
 Not currently planned (may be revisited later): graph view, query blocks, task states, flashcards, PDF annotation, whiteboards, and a plugin ecosystem.
 
+## Notes storage
+
+Pages are stored as plain `.md` files in a notes root directory:
+
+- Linux: `$XDG_DATA_HOME/gpui-notes` (falls back to `~/.local/share/gpui-notes`)
+- macOS: `~/Library/Application Support/gpui-notes`
+- Windows: `%APPDATA%\gpui-notes`
+
+Override the location with the `GPUI_NOTES_ROOT` environment variable (must be an absolute path).
+
 ## GPUI dependency
 
 GPUI is not published to crates.io. We depend on it (and `gpui_platform`) directly from the [`zed-industries/zed`](https://github.com/zed-industries/zed) repository. Because that repo is Zed's active development trunk, its API changes without warning — the scaffold emitted by `create-gpui-app` has already drifted from HEAD at least once (e.g. `Application::new()` was removed in favor of `gpui_platform::application()`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod store;

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,119 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+pub struct NotesStore {
+    root: PathBuf,
+}
+
+impl NotesStore {
+    /// # Errors
+    /// Returns an error if `root` cannot be created.
+    pub fn new(root: impl Into<PathBuf>) -> io::Result<Self> {
+        let root = root.into();
+        fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// # Errors
+    /// Returns an error if `GPUI_NOTES_ROOT` is set but not absolute, or if the
+    /// platform data directory cannot be determined.
+    pub fn default_root() -> io::Result<PathBuf> {
+        if let Some(override_root) = std::env::var_os("GPUI_NOTES_ROOT") {
+            let p = PathBuf::from(override_root);
+            if !p.is_absolute() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "GPUI_NOTES_ROOT must be an absolute path",
+                ));
+            }
+            return Ok(p);
+        }
+        let data_dir = dirs::data_dir().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "could not determine platform data directory",
+            )
+        })?;
+        Ok(data_dir.join("gpui-notes"))
+    }
+
+    /// # Errors
+    /// Returns `InvalidInput` for an invalid page name, `NotFound` if the page
+    /// does not exist, or another I/O error on read failure.
+    pub fn read(&self, name: &str) -> io::Result<String> {
+        fs::read_to_string(self.page_path(name)?)
+    }
+
+    /// # Errors
+    /// Returns `InvalidInput` for an invalid page name, or another I/O error
+    /// if the write or atomic rename fails.
+    pub fn write(&self, name: &str, body: &str) -> io::Result<()> {
+        let final_path = self.page_path(name)?;
+        let tmp_path = self.root.join(format!("{name}.md.tmp"));
+
+        let result = (|| -> io::Result<()> {
+            let mut f = fs::File::create(&tmp_path)?;
+            f.write_all(body.as_bytes())?;
+            f.sync_all()?;
+            drop(f);
+            fs::rename(&tmp_path, &final_path)
+        })();
+
+        if result.is_err() {
+            let _ = fs::remove_file(&tmp_path);
+        }
+        result
+    }
+
+    /// # Errors
+    /// Returns an I/O error if the notes root cannot be read.
+    pub fn list(&self) -> io::Result<Vec<String>> {
+        let mut names = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let path = entry?.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("md") {
+                continue;
+            }
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                names.push(stem.to_string());
+            }
+        }
+        names.sort();
+        Ok(names)
+    }
+
+    #[must_use]
+    pub fn exists(&self, name: &str) -> bool {
+        self.page_path(name).is_ok_and(|p| p.is_file())
+    }
+
+    /// # Errors
+    /// Returns `InvalidInput` for an invalid page name, `NotFound` if the page
+    /// does not exist, or another I/O error on removal failure.
+    pub fn delete(&self, name: &str) -> io::Result<()> {
+        fs::remove_file(self.page_path(name)?)
+    }
+
+    fn page_path(&self, name: &str) -> io::Result<PathBuf> {
+        validate_name(name)?;
+        Ok(self.root.join(format!("{name}.md")))
+    }
+}
+
+fn validate_name(name: &str) -> io::Result<()> {
+    let invalid =
+        name.is_empty() || name.starts_with('.') || name.contains('/') || name.contains('\\');
+    if invalid {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid page name: {name:?}"),
+        ));
+    }
+    Ok(())
+}

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -1,0 +1,85 @@
+use std::fs;
+use std::io::ErrorKind;
+
+use gpui_notes::store::NotesStore;
+use tempfile::TempDir;
+
+fn new_store() -> (TempDir, NotesStore) {
+    let tmp = TempDir::new().expect("create tempdir");
+    let store = NotesStore::new(tmp.path()).expect("create store");
+    (tmp, store)
+}
+
+#[test]
+fn round_trip_read_write() {
+    let (_tmp, store) = new_store();
+    store.write("foo", "bar").unwrap();
+    assert_eq!(store.read("foo").unwrap(), "bar");
+}
+
+#[test]
+fn list_returns_sorted_md_stems_only() {
+    let (tmp, store) = new_store();
+    store.write("beta", "b").unwrap();
+    store.write("alpha", "a").unwrap();
+    fs::write(tmp.path().join("ignored.txt"), "x").unwrap();
+    fs::write(tmp.path().join("leftover.md.tmp"), "x").unwrap();
+
+    assert_eq!(store.list().unwrap(), vec!["alpha", "beta"]);
+}
+
+#[test]
+fn successful_write_leaves_no_tmp_file() {
+    let (tmp, store) = new_store();
+    store.write("page", "hello").unwrap();
+
+    let tmp_present = fs::read_dir(tmp.path())
+        .unwrap()
+        .any(|e| e.unwrap().path().extension().and_then(|s| s.to_str()) == Some("tmp"));
+    assert!(
+        !tmp_present,
+        "tmp file should not remain after successful write"
+    );
+}
+
+#[test]
+fn invalid_names_are_rejected() {
+    let (_tmp, store) = new_store();
+    for bad in ["a/b", "a\\b", "", "..", ".", ".hidden"] {
+        let err = store.write(bad, "x").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidInput, "name {bad:?}");
+    }
+}
+
+#[test]
+fn read_missing_page_is_not_found() {
+    let (_tmp, store) = new_store();
+    let err = store.read("missing").unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+}
+
+#[test]
+fn overwrite_replaces_content() {
+    let (_tmp, store) = new_store();
+    store.write("p", "first").unwrap();
+    store.write("p", "second").unwrap();
+    assert_eq!(store.read("p").unwrap(), "second");
+}
+
+#[test]
+fn exists_reflects_filesystem_state() {
+    let (_tmp, store) = new_store();
+    assert!(!store.exists("p"));
+    store.write("p", "x").unwrap();
+    assert!(store.exists("p"));
+    assert!(!store.exists("a/b"));
+}
+
+#[test]
+fn delete_removes_page() {
+    let (_tmp, store) = new_store();
+    store.write("p", "x").unwrap();
+    store.delete("p").unwrap();
+    assert!(!store.exists("p"));
+    assert_eq!(store.read("p").unwrap_err().kind(), ErrorKind::NotFound);
+}


### PR DESCRIPTION
Implements NotesStore with atomic writes (tmp + fsync + rename), read, list (sorted .md stems), exists, delete, and a platform-aware default root honoring GPUI_NOTES_ROOT. Closes #1.