### PR TITLE
feat(store): match Logseq on-disk layout with pages/, journals/, %2F …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,6 +2160,7 @@ dependencies = [
 name = "gpui-notes"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "dirs 5.0.1",
  "gpui",
  "gpui_platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3
 # use `cargo add smallvec` to add it to your project
 smallvec = "1.13.2"
 dirs = "5"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 gpui = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3", features = ["test-support"] }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,11 @@
+use chrono::NaiveDate;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+
+const PAGES_DIR: &str = "pages";
+const JOURNALS_DIR: &str = "journals";
+const JOURNAL_DATE_FMT: &str = "%Y_%m_%d";
 
 pub struct NotesStore {
     root: PathBuf,
@@ -8,10 +13,12 @@ pub struct NotesStore {
 
 impl NotesStore {
     /// # Errors
-    /// Returns an error if `root` cannot be created.
+    /// Returns an error if `root` or its `pages/`/`journals/` subdirectories
+    /// cannot be created.
     pub fn new(root: impl Into<PathBuf>) -> io::Result<Self> {
         let root = root.into();
-        fs::create_dir_all(&root)?;
+        fs::create_dir_all(root.join(PAGES_DIR))?;
+        fs::create_dir_all(root.join(JOURNALS_DIR))?;
         Ok(Self { root })
     }
 
@@ -55,33 +62,20 @@ impl NotesStore {
     /// if the write or atomic rename fails.
     pub fn write(&self, name: &str, body: &str) -> io::Result<()> {
         let final_path = self.page_path(name)?;
-        let tmp_path = self.root.join(format!("{name}.md.tmp"));
-
-        let result = (|| -> io::Result<()> {
-            let mut f = fs::File::create(&tmp_path)?;
-            f.write_all(body.as_bytes())?;
-            f.sync_all()?;
-            drop(f);
-            fs::rename(&tmp_path, &final_path)
-        })();
-
-        if result.is_err() {
-            let _ = fs::remove_file(&tmp_path);
-        }
-        result
+        atomic_write(&final_path, body)
     }
 
     /// # Errors
-    /// Returns an I/O error if the notes root cannot be read.
+    /// Returns an I/O error if the `pages/` directory cannot be read.
     pub fn list(&self) -> io::Result<Vec<String>> {
         let mut names = Vec::new();
-        for entry in fs::read_dir(&self.root)? {
+        for entry in fs::read_dir(self.root.join(PAGES_DIR))? {
             let path = entry?.path();
             if path.extension().and_then(|s| s.to_str()) != Some("md") {
                 continue;
             }
             if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                names.push(stem.to_string());
+                names.push(decode_page_name(stem));
             }
         }
         names.sort();
@@ -100,15 +94,90 @@ impl NotesStore {
         fs::remove_file(self.page_path(name)?)
     }
 
+    /// # Errors
+    /// Returns `NotFound` if no journal exists for `date`, or another I/O error
+    /// on read failure.
+    pub fn read_journal(&self, date: NaiveDate) -> io::Result<String> {
+        fs::read_to_string(self.journal_path(date))
+    }
+
+    /// # Errors
+    /// Returns an I/O error if the write or atomic rename fails.
+    pub fn write_journal(&self, date: NaiveDate, body: &str) -> io::Result<()> {
+        atomic_write(&self.journal_path(date), body)
+    }
+
+    /// # Errors
+    /// Returns an I/O error if the `journals/` directory cannot be read.
+    pub fn list_journals(&self) -> io::Result<Vec<NaiveDate>> {
+        let mut dates = Vec::new();
+        for entry in fs::read_dir(self.root.join(JOURNALS_DIR))? {
+            let path = entry?.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("md") {
+                continue;
+            }
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                if let Ok(d) = NaiveDate::parse_from_str(stem, JOURNAL_DATE_FMT) {
+                    dates.push(d);
+                }
+            }
+        }
+        dates.sort();
+        Ok(dates)
+    }
+
+    #[must_use]
+    pub fn journal_exists(&self, date: NaiveDate) -> bool {
+        self.journal_path(date).is_file()
+    }
+
+    /// # Errors
+    /// Returns `NotFound` if no journal exists for `date`, or another I/O error
+    /// on removal failure.
+    pub fn delete_journal(&self, date: NaiveDate) -> io::Result<()> {
+        fs::remove_file(self.journal_path(date))
+    }
+
     fn page_path(&self, name: &str) -> io::Result<PathBuf> {
         validate_name(name)?;
-        Ok(self.root.join(format!("{name}.md")))
+        let encoded = encode_page_name(name);
+        Ok(self.root.join(PAGES_DIR).join(format!("{encoded}.md")))
+    }
+
+    fn journal_path(&self, date: NaiveDate) -> PathBuf {
+        self.root
+            .join(JOURNALS_DIR)
+            .join(format!("{}.md", date.format(JOURNAL_DATE_FMT)))
     }
 }
 
+fn atomic_write(final_path: &Path, body: &str) -> io::Result<()> {
+    let mut tmp_path = final_path.to_path_buf();
+    let tmp_name = format!(
+        "{}.tmp",
+        final_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .expect("final_path built from validated name"),
+    );
+    tmp_path.set_file_name(tmp_name);
+
+    let result = (|| -> io::Result<()> {
+        let mut f = fs::File::create(&tmp_path)?;
+        f.write_all(body.as_bytes())?;
+        f.sync_all()?;
+        drop(f);
+        fs::rename(&tmp_path, final_path)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    result
+}
+
 fn validate_name(name: &str) -> io::Result<()> {
-    let invalid =
-        name.is_empty() || name.starts_with('.') || name.contains('/') || name.contains('\\');
+    let invalid = name.is_empty() || name.starts_with('.') || name.contains('\\');
     if invalid {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -116,4 +185,36 @@ fn validate_name(name: &str) -> io::Result<()> {
         ));
     }
     Ok(())
+}
+
+// Logseq uses URL-encoded `/` (`%2F`) in page filenames to represent namespaces.
+// We only substitute `/` here — literal `%` in names round-trips as-is, matching
+// Logseq's on-disk behavior. A name containing a literal `%2F` substring would
+// collide with an encoded `/`; that edge case is out of scope (see issue #14).
+fn encode_page_name(name: &str) -> String {
+    name.replace('/', "%2F")
+}
+
+fn decode_page_name(encoded: &str) -> String {
+    encoded.replace("%2F", "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_page_name, encode_page_name};
+
+    #[test]
+    fn encode_roundtrips_slash() {
+        let name = "Projects/Alpha";
+        let encoded = encode_page_name(name);
+        assert_eq!(encoded, "Projects%2FAlpha");
+        assert_eq!(decode_page_name(&encoded), name);
+    }
+
+    #[test]
+    fn encode_passes_through_unicode_and_percent() {
+        for name in ["日本語", "a%b", "plain", "a/b/c"] {
+            assert_eq!(decode_page_name(&encode_page_name(name)), name);
+        }
+    }
 }

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::io::ErrorKind;
 
+use chrono::NaiveDate;
 use gpui_notes::store::NotesStore;
 use tempfile::TempDir;
 
@@ -18,12 +19,20 @@ fn round_trip_read_write() {
 }
 
 #[test]
+fn new_creates_pages_and_journals_subdirs() {
+    let (tmp, _store) = new_store();
+    assert!(tmp.path().join("pages").is_dir());
+    assert!(tmp.path().join("journals").is_dir());
+}
+
+#[test]
 fn list_returns_sorted_md_stems_only() {
     let (tmp, store) = new_store();
     store.write("beta", "b").unwrap();
     store.write("alpha", "a").unwrap();
-    fs::write(tmp.path().join("ignored.txt"), "x").unwrap();
-    fs::write(tmp.path().join("leftover.md.tmp"), "x").unwrap();
+    let pages = tmp.path().join("pages");
+    fs::write(pages.join("ignored.txt"), "x").unwrap();
+    fs::write(pages.join("leftover.md.tmp"), "x").unwrap();
 
     assert_eq!(store.list().unwrap(), vec!["alpha", "beta"]);
 }
@@ -33,7 +42,7 @@ fn successful_write_leaves_no_tmp_file() {
     let (tmp, store) = new_store();
     store.write("page", "hello").unwrap();
 
-    let tmp_present = fs::read_dir(tmp.path())
+    let tmp_present = fs::read_dir(tmp.path().join("pages"))
         .unwrap()
         .any(|e| e.unwrap().path().extension().and_then(|s| s.to_str()) == Some("tmp"));
     assert!(
@@ -45,7 +54,7 @@ fn successful_write_leaves_no_tmp_file() {
 #[test]
 fn invalid_names_are_rejected() {
     let (_tmp, store) = new_store();
-    for bad in ["a/b", "a\\b", "", "..", ".", ".hidden"] {
+    for bad in ["a\\b", "", "..", ".", ".hidden"] {
         let err = store.write(bad, "x").unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidInput, "name {bad:?}");
     }
@@ -72,7 +81,6 @@ fn exists_reflects_filesystem_state() {
     assert!(!store.exists("p"));
     store.write("p", "x").unwrap();
     assert!(store.exists("p"));
-    assert!(!store.exists("a/b"));
 }
 
 #[test]
@@ -82,4 +90,100 @@ fn delete_removes_page() {
     store.delete("p").unwrap();
     assert!(!store.exists("p"));
     assert_eq!(store.read("p").unwrap_err().kind(), ErrorKind::NotFound);
+}
+
+#[test]
+fn namespaced_page_writes_encoded_file_and_lists_decoded() {
+    let (tmp, store) = new_store();
+    store.write("Projects/Alpha", "hi").unwrap();
+
+    assert!(tmp.path().join("pages/Projects%2FAlpha.md").is_file());
+    assert_eq!(store.read("Projects/Alpha").unwrap(), "hi");
+    assert_eq!(store.list().unwrap(), vec!["Projects/Alpha"]);
+    assert!(store.exists("Projects/Alpha"));
+}
+
+#[test]
+fn namespaced_page_reads_existing_encoded_file() {
+    let (tmp, store) = new_store();
+    fs::write(tmp.path().join("pages/A%2FB%2FC.md"), "deep").unwrap();
+
+    assert_eq!(store.read("A/B/C").unwrap(), "deep");
+    assert_eq!(store.list().unwrap(), vec!["A/B/C"]);
+}
+
+#[test]
+fn journal_round_trip() {
+    let (tmp, store) = new_store();
+    let date = NaiveDate::from_ymd_opt(2026, 4, 18).unwrap();
+    store.write_journal(date, "today").unwrap();
+
+    assert!(tmp.path().join("journals/2026_04_18.md").is_file());
+    assert_eq!(store.read_journal(date).unwrap(), "today");
+    assert!(store.journal_exists(date));
+    assert_eq!(store.list_journals().unwrap(), vec![date]);
+}
+
+#[test]
+fn list_journals_skips_non_date_and_non_md_files() {
+    let (tmp, store) = new_store();
+    let d1 = NaiveDate::from_ymd_opt(2026, 1, 2).unwrap();
+    let d2 = NaiveDate::from_ymd_opt(2025, 12, 31).unwrap();
+    store.write_journal(d1, "a").unwrap();
+    store.write_journal(d2, "b").unwrap();
+    let journals = tmp.path().join("journals");
+    fs::write(journals.join("notes.txt"), "x").unwrap();
+    fs::write(journals.join("not_a_date.md"), "x").unwrap();
+
+    assert_eq!(store.list_journals().unwrap(), vec![d2, d1]);
+}
+
+#[test]
+fn delete_journal_removes_file() {
+    let (_tmp, store) = new_store();
+    let date = NaiveDate::from_ymd_opt(2026, 4, 18).unwrap();
+    store.write_journal(date, "x").unwrap();
+    store.delete_journal(date).unwrap();
+    assert!(!store.journal_exists(date));
+    assert_eq!(
+        store.read_journal(date).unwrap_err().kind(),
+        ErrorKind::NotFound
+    );
+}
+
+#[test]
+fn list_ignores_logseq_graph_subdirs() {
+    let (tmp, store) = new_store();
+    store.write("Welcome", "hi").unwrap();
+    for dir in ["assets", "logseq", ".recycle", "bak"] {
+        let p = tmp.path().join(dir);
+        fs::create_dir_all(&p).unwrap();
+        fs::write(p.join("stuff.md"), "ignored").unwrap();
+    }
+
+    assert_eq!(store.list().unwrap(), vec!["Welcome"]);
+}
+
+#[test]
+fn opens_existing_logseq_style_graph() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    // Simulate a real Logseq graph laid out on disk.
+    fs::create_dir_all(root.join("pages")).unwrap();
+    fs::create_dir_all(root.join("journals")).unwrap();
+    fs::create_dir_all(root.join("assets")).unwrap();
+    fs::create_dir_all(root.join("logseq")).unwrap();
+    fs::write(root.join("pages/Welcome.md"), "hi").unwrap();
+    fs::write(root.join("pages/Projects%2FAlpha.md"), "alpha body").unwrap();
+    fs::write(root.join("journals/2026_04_18.md"), "j").unwrap();
+    fs::write(root.join("assets/ignored.md"), "x").unwrap();
+
+    let store = NotesStore::new(root).unwrap();
+
+    assert_eq!(store.list().unwrap(), vec!["Projects/Alpha", "Welcome"]);
+    assert_eq!(store.read("Projects/Alpha").unwrap(), "alpha body");
+    assert_eq!(
+        store.list_journals().unwrap(),
+        vec![NaiveDate::from_ymd_opt(2026, 4, 18).unwrap()]
+    );
 }


### PR DESCRIPTION
…namespacing

Closes #14

- NotesStore::new now creates pages/ and journals/ subdirectories.
- Pages stored at pages/{encoded}.md; encode_page_name/decode_page_name substitute / <-> %2F so Logseq namespaces round-trip transparently.
- Journal API keyed by chrono::NaiveDate (journals/YYYY_MM_DD.md): read_journal, write_journal, list_journals, journal_exists, delete_journal.
- Page-name validation now allows /; still rejects empty, leading-., and \\.
- list() reads only pages/, so assets/, logseq/, .recycle/, bak/ are ignored automatically.