### PR TITLE
feat(page): Page model, registry, and navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,6 +2170,7 @@ dependencies = [
  "dirs 5.0.1",
  "gpui",
  "gpui_platform",
+ "rstest",
  "smallvec",
  "tempfile",
 ]
@@ -4423,6 +4430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4459,6 +4472,35 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
 
 [[package]]
 name = "rust-embed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ chrono = { version = "0.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 gpui = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3", features = ["test-support"] }
+rstest = "0.26.1"
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod page;
+pub mod registry;
 pub mod store;
 pub mod text_input;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unreadable_literal)]
+
 pub mod page;
 pub mod registry;
 pub mod store;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,80 +1,155 @@
 #![allow(clippy::unreadable_literal)]
 
 use gpui::{
-    div, prelude::*, px, rgb, size, App, AppContext, Bounds, Context, Entity, FocusHandle,
-    Focusable, IntoElement, ParentElement, Render, Styled, Window, WindowBounds, WindowOptions,
+    actions, div, prelude::*, px, rgb, size, App, AppContext, Bounds, Context, Entity, FocusHandle,
+    Focusable, IntoElement, KeyBinding, ParentElement, Render, SharedString, Styled, Subscription,
+    Window, WindowBounds, WindowOptions,
 };
-use gpui_notes::text_input::{self, TextInput, TextInputEvent};
+use gpui_notes::page::Page;
+use gpui_notes::registry::{set_current_page, CurrentPage, PageRegistry};
+use gpui_notes::store::NotesStore;
+use gpui_notes::text_input;
 use gpui_platform::application;
 
-struct Demo {
-    input: Entity<TextInput>,
+const DEFAULT_PAGE: &str = "scratch";
+
+actions!(gpui_notes, [SavePage, NextPage]);
+
+struct RootView {
     focus_handle: FocusHandle,
-    _subscription: gpui::Subscription,
+    _observer: Subscription,
 }
 
-impl Focusable for Demo {
+impl RootView {
+    fn new(cx: &mut Context<Self>) -> Self {
+        let observer = cx.observe_global::<CurrentPage>(|_, cx| cx.notify());
+        Self {
+            focus_handle: cx.focus_handle(),
+            _observer: observer,
+        }
+    }
+
+    #[allow(clippy::unused_self, clippy::needless_pass_by_ref_mut)]
+    fn save_current(&mut self, _: &SavePage, _: &mut Window, cx: &mut Context<Self>) {
+        let Some(page) = cx.global::<CurrentPage>().get().cloned() else {
+            return;
+        };
+        let result = cx.update_global::<PageRegistry, _>(|reg, cx| reg.save(&page, cx));
+        if let Err(err) = result {
+            eprintln!("save failed: {err}");
+        }
+    }
+
+    #[allow(clippy::unused_self, clippy::needless_pass_by_ref_mut)]
+    fn next_page(&mut self, _: &NextPage, _: &mut Window, cx: &mut Context<Self>) {
+        let names = match cx.global::<PageRegistry>().list() {
+            Ok(names) => names,
+            Err(err) => {
+                eprintln!("list failed: {err}");
+                return;
+            }
+        };
+        if names.is_empty() {
+            return;
+        }
+        let current = cx
+            .global::<CurrentPage>()
+            .get()
+            .map(|p| p.read(cx).name().clone());
+        let next = pick_next(&names, current.as_ref());
+        if let Err(err) = set_current_page(next.as_ref(), cx) {
+            eprintln!("open {next:?} failed: {err}");
+        }
+    }
+}
+
+fn pick_next<'a>(names: &'a [SharedString], current: Option<&SharedString>) -> &'a SharedString {
+    let idx = current
+        .and_then(|c| names.iter().position(|n| n == c))
+        .map_or(0, |i| (i + 1) % names.len());
+    &names[idx]
+}
+
+impl Focusable for RootView {
     fn focus_handle(&self, _: &App) -> FocusHandle {
         self.focus_handle.clone()
     }
 }
 
-impl Render for Demo {
+impl Render for RootView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let current: Option<Entity<Page>> = cx.global::<CurrentPage>().get().cloned();
+
         let mut root = div()
             .track_focus(&self.focus_handle(cx))
+            .key_context("RootView")
+            .on_action(cx.listener(Self::save_current))
+            .on_action(cx.listener(Self::next_page))
             .flex()
             .flex_col()
             .size_full()
             .bg(rgb(0x1e1e1e))
             .p_4()
             .gap_2();
-        // Inherit emoji fallbacks to every descendant's text style.
         root.text_style().font_fallbacks = Some(text_input::emoji_font_fallbacks());
+
+        let Some(page) = current else {
+            return root.child(div().text_color(rgb(0xcccccc)).child("No page open."));
+        };
+
+        let (name, dirty, input) = {
+            let p = page.read(cx);
+            (p.name().clone(), p.dirty(), p.input().clone())
+        };
+        let header = if dirty {
+            format!("{name} •")
+        } else {
+            name.to_string()
+        };
+
         root.child(
             div()
                 .text_color(rgb(0xcccccc))
-                .text_size(px(12.))
-                .child("TextInput demo — Changed/Submitted events log to stderr."),
+                .text_size(px(14.))
+                .child(header),
         )
-        .child(self.input.clone())
+        .child(input)
     }
 }
 
 fn main() {
     application().run(|cx: &mut App| {
         text_input::bind_keys(cx);
+        cx.bind_keys([
+            KeyBinding::new("cmd-s", SavePage, Some("RootView")),
+            KeyBinding::new("cmd-p", NextPage, Some("RootView")),
+        ]);
 
-        let bounds = Bounds::centered(None, size(px(480.0), px(140.0)), cx);
+        let root_dir = NotesStore::default_root().expect("resolve notes root");
+        let store = NotesStore::new(root_dir).expect("init notes store");
+        cx.set_global(PageRegistry::new(store));
+        cx.set_global(CurrentPage::default());
+        set_current_page(DEFAULT_PAGE, cx).expect("open default page");
+
+        let bounds = Bounds::centered(None, size(px(640.0), px(420.0)), cx);
         let window = cx
             .open_window(
                 WindowOptions {
                     window_bounds: Some(WindowBounds::Windowed(bounds)),
                     ..Default::default()
                 },
-                |_, cx| {
-                    cx.new(|cx| {
-                        let input = cx.new(|cx| TextInput::new(cx, "Type here..."));
-                        let sub =
-                            cx.subscribe(&input, |_: &mut Demo, _, event: &TextInputEvent, _| {
-                                match event {
-                                    TextInputEvent::Changed(s) => eprintln!("changed: {s:?}"),
-                                    TextInputEvent::Submitted => eprintln!("submitted"),
-                                }
-                            });
-                        Demo {
-                            input,
-                            focus_handle: cx.focus_handle(),
-                            _subscription: sub,
-                        }
-                    })
-                },
+                |_, cx| cx.new(RootView::new),
             )
             .unwrap();
 
         window
             .update(cx, |view, window, cx| {
-                window.focus(&view.input.focus_handle(cx), cx);
+                if let Some(page) = cx.global::<CurrentPage>().get() {
+                    let input = page.read(cx).input().clone();
+                    window.focus(&input.focus_handle(cx), cx);
+                } else {
+                    window.focus(&view.focus_handle(cx), cx);
+                }
                 cx.activate(true);
             })
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,9 +120,14 @@ impl Render for RootView {
 fn main() {
     application().run(|cx: &mut App| {
         text_input::bind_keys(cx);
+        let cmd = if cfg!(target_os = "macos") {
+            "cmd"
+        } else {
+            "ctrl"
+        };
         cx.bind_keys([
-            KeyBinding::new("cmd-s", SavePage, Some("RootView")),
-            KeyBinding::new("cmd-p", NextPage, Some("RootView")),
+            KeyBinding::new(&format!("{cmd}-s"), SavePage, Some("RootView")),
+            KeyBinding::new(&format!("{cmd}-p"), NextPage, Some("RootView")),
         ]);
 
         let root_dir = NotesStore::default_root().expect("resolve notes root");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@
 
 use gpui::{
     actions, div, prelude::*, px, rgb, size, App, AppContext, Bounds, Context, Entity, FocusHandle,
-    Focusable, IntoElement, KeyBinding, ParentElement, Render, SharedString, Styled, Subscription,
-    Window, WindowBounds, WindowOptions,
+    Focusable, IntoElement, KeyBinding, ParentElement, Render, Styled, Subscription, Window,
+    WindowBounds, WindowOptions,
 };
 use gpui_notes::page::Page;
-use gpui_notes::registry::{set_current_page, CurrentPage, PageRegistry};
+use gpui_notes::registry::{pick_next, set_current_page, CurrentPage, PageRegistry};
 use gpui_notes::store::NotesStore;
 use gpui_notes::text_input;
 use gpui_platform::application;
@@ -49,25 +49,17 @@ impl RootView {
                 return;
             }
         };
-        if names.is_empty() {
-            return;
-        }
         let current = cx
             .global::<CurrentPage>()
             .get()
             .map(|p| p.read(cx).name().clone());
-        let next = pick_next(&names, current.as_ref());
+        let Some(next) = pick_next(&names, current.as_ref()) else {
+            return;
+        };
         if let Err(err) = set_current_page(next.as_ref(), cx) {
             eprintln!("open {next:?} failed: {err}");
         }
     }
-}
-
-fn pick_next<'a>(names: &'a [SharedString], current: Option<&SharedString>) -> &'a SharedString {
-    let idx = current
-        .and_then(|c| names.iter().position(|n| n == c))
-        .map_or(0, |i| (i + 1) % names.len());
-    &names[idx]
 }
 
 impl Focusable for RootView {

--- a/src/page.rs
+++ b/src/page.rs
@@ -80,3 +80,37 @@ impl Page {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    fn input_edits_propagate_to_page(cx: &mut TestAppContext) {
+        let page = cx.new(|cx| Page::new("foo".into(), String::new(), cx));
+        let input = cx.read(|cx| page.read(cx).input().clone());
+
+        cx.update(|cx| {
+            input.update(cx, |i, cx| i.test_replace_all("hello", cx));
+        });
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let p = page.read(cx);
+            assert_eq!(p.body().as_ref(), "hello");
+            assert!(p.dirty());
+        });
+    }
+
+    #[gpui::test]
+    fn page_starts_clean_with_preloaded_body(cx: &mut TestAppContext) {
+        let page = cx.new(|cx| Page::new("foo".into(), "preloaded".into(), cx));
+        cx.run_until_parked();
+        cx.read(|cx| {
+            let p = page.read(cx);
+            assert_eq!(p.body().as_ref(), "preloaded");
+            assert!(!p.dirty(), "hydrating body must not mark the page dirty");
+        });
+    }
+}

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,0 +1,82 @@
+use gpui::{AppContext, Context, Entity, EventEmitter, SharedString, Subscription};
+
+use crate::text_input::{TextInput, TextInputEvent};
+
+#[derive(Debug, Clone)]
+pub enum PageEvent {
+    Saved,
+}
+
+pub struct Page {
+    name: SharedString,
+    body: SharedString,
+    input: Entity<TextInput>,
+    dirty: bool,
+    _input_sub: Subscription,
+}
+
+impl EventEmitter<PageEvent> for Page {}
+
+impl Page {
+    pub fn new(name: SharedString, body: String, cx: &mut Context<Self>) -> Self {
+        let body: SharedString = body.into();
+        let input = cx.new({
+            let body = body.clone();
+            |cx| TextInput::with_content(cx, "", body)
+        });
+        let input_sub = cx.subscribe(&input, |this, _, event: &TextInputEvent, cx| {
+            if let TextInputEvent::Changed(new_body) = event {
+                if new_body != &this.body {
+                    this.body = new_body.clone();
+                    this.dirty = true;
+                    cx.notify();
+                }
+            }
+        });
+        Self {
+            name,
+            body,
+            input,
+            dirty: false,
+            _input_sub: input_sub,
+        }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &SharedString {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn body(&self) -> &SharedString {
+        &self.body
+    }
+
+    #[must_use]
+    pub fn input(&self) -> &Entity<TextInput> {
+        &self.input
+    }
+
+    #[must_use]
+    pub fn dirty(&self) -> bool {
+        self.dirty
+    }
+
+    pub fn mark_saved(&mut self, cx: &mut Context<Self>) {
+        if self.dirty {
+            self.dirty = false;
+            cx.notify();
+        }
+        cx.emit(PageEvent::Saved);
+    }
+
+    #[cfg(test)]
+    pub fn set_body_for_test(&mut self, body: impl Into<SharedString>, cx: &mut Context<Self>) {
+        let body = body.into();
+        if body != self.body {
+            self.body = body;
+            self.dirty = true;
+            cx.notify();
+        }
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -247,39 +247,28 @@ mod tests {
         });
     }
 
-    fn names(items: &[&str]) -> Vec<SharedString> {
-        items
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::empty_no_current(&[], None, None)]
+    #[case::empty_with_current(&[], Some("foo"), None)]
+    #[case::wraps_after_last(&["a", "b", "c"], Some("c"), Some("a"))]
+    #[case::advances_from_first(&["a", "b", "c"], Some("a"), Some("b"))]
+    #[case::advances_from_middle(&["a", "b", "c"], Some("b"), Some("c"))]
+    #[case::orphan_current_falls_back_to_first(&["a", "b"], Some("zzz"), Some("a"))]
+    #[case::no_current_falls_back_to_first(&["a", "b"], None, Some("a"))]
+    fn pick_next_cases(
+        #[case] names: &[&str],
+        #[case] current: Option<&str>,
+        #[case] expected: Option<&str>,
+    ) {
+        let ns: Vec<SharedString> = names
             .iter()
             .map(|s| SharedString::from(s.to_string()))
-            .collect()
-    }
-
-    #[test]
-    fn pick_next_empty_returns_none() {
-        assert!(pick_next(&[], None).is_none());
-        let current = SharedString::from("foo");
-        assert!(pick_next(&[], Some(&current)).is_none());
-    }
-
-    #[test]
-    fn pick_next_wraps_after_last() {
-        let ns = names(&["a", "b", "c"]);
-        assert_eq!(pick_next(&ns, Some(&ns[2])).unwrap().as_ref(), "a");
-    }
-
-    #[test]
-    fn pick_next_advances_from_current() {
-        let ns = names(&["a", "b", "c"]);
-        assert_eq!(pick_next(&ns, Some(&ns[0])).unwrap().as_ref(), "b");
-        assert_eq!(pick_next(&ns, Some(&ns[1])).unwrap().as_ref(), "c");
-    }
-
-    #[test]
-    fn pick_next_falls_back_to_first_when_current_missing() {
-        let ns = names(&["a", "b"]);
-        let orphan = SharedString::from("zzz");
-        assert_eq!(pick_next(&ns, Some(&orphan)).unwrap().as_ref(), "a");
-        assert_eq!(pick_next(&ns, None).unwrap().as_ref(), "a");
+            .collect();
+        let current = current.map(|s| SharedString::from(s.to_string()));
+        let picked = pick_next(&ns, current.as_ref());
+        assert_eq!(picked.map(|s| s.as_ref()), expected);
     }
 
     #[gpui::test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,216 @@
+use std::collections::HashMap;
+use std::io;
+
+use gpui::{App, AppContext, BorrowAppContext, Entity, Global, SharedString};
+
+use crate::page::Page;
+use crate::store::NotesStore;
+
+pub struct PageRegistry {
+    store: NotesStore,
+    open: HashMap<SharedString, Entity<Page>>,
+}
+
+impl Global for PageRegistry {}
+
+impl PageRegistry {
+    #[must_use]
+    pub fn new(store: NotesStore) -> Self {
+        Self {
+            store,
+            open: HashMap::new(),
+        }
+    }
+
+    /// Opens an existing page.
+    ///
+    /// # Errors
+    /// Returns `NotFound` if the page does not exist on disk, or a store I/O error.
+    pub fn open(&mut self, name: &str, cx: &mut App) -> io::Result<Entity<Page>> {
+        let key: SharedString = name.to_string().into();
+        if let Some(page) = self.open.get(&key) {
+            return Ok(page.clone());
+        }
+        let body = self.store.read(name)?;
+        Ok(self.insert(key, body, cx))
+    }
+
+    /// Opens a page, creating it (empty) on disk if it does not yet exist.
+    ///
+    /// # Errors
+    /// Returns any I/O error from the underlying store other than `NotFound`
+    /// (which triggers creation).
+    pub fn open_or_create(&mut self, name: &str, cx: &mut App) -> io::Result<Entity<Page>> {
+        let key: SharedString = name.to_string().into();
+        if let Some(page) = self.open.get(&key) {
+            return Ok(page.clone());
+        }
+        let body = match self.store.read(name) {
+            Ok(body) => body,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                self.store.write(name, "")?;
+                String::new()
+            }
+            Err(err) => return Err(err),
+        };
+        Ok(self.insert(key, body, cx))
+    }
+
+    /// Lists all page names available on disk.
+    ///
+    /// # Errors
+    /// Returns an I/O error if the pages directory cannot be read.
+    pub fn list(&self) -> io::Result<Vec<SharedString>> {
+        Ok(self
+            .store
+            .list()?
+            .into_iter()
+            .map(SharedString::from)
+            .collect())
+    }
+
+    /// Writes the page's body to disk if dirty and clears the dirty flag.
+    ///
+    /// # Errors
+    /// Returns an I/O error if the write fails.
+    pub fn save(&mut self, page: &Entity<Page>, cx: &mut App) -> io::Result<()> {
+        let (name, body, dirty) = {
+            let page = page.read(cx);
+            (page.name().clone(), page.body().clone(), page.dirty())
+        };
+        if !dirty {
+            return Ok(());
+        }
+        self.store.write(&name, &body)?;
+        page.update(cx, Page::mark_saved);
+        Ok(())
+    }
+
+    fn insert(&mut self, key: SharedString, body: String, cx: &mut App) -> Entity<Page> {
+        let page = cx.new(|cx| Page::new(key.clone(), body, cx));
+        self.open.insert(key, page.clone());
+        page
+    }
+}
+
+#[derive(Default)]
+pub struct CurrentPage {
+    current: Option<Entity<Page>>,
+}
+
+impl Global for CurrentPage {}
+
+impl CurrentPage {
+    #[must_use]
+    pub fn get(&self) -> Option<&Entity<Page>> {
+        self.current.as_ref()
+    }
+}
+
+/// Saves the outgoing current page if dirty, opens `name` (creating if missing),
+/// and sets it as the current page.
+///
+/// # Errors
+/// Returns any I/O error from saving the outgoing page or opening the incoming one.
+pub fn set_current_page(name: &str, cx: &mut App) -> io::Result<()> {
+    let outgoing = cx.global::<CurrentPage>().current.clone();
+    let page = cx.update_global::<PageRegistry, io::Result<Entity<Page>>>(|reg, cx| {
+        if let Some(outgoing) = &outgoing {
+            reg.save(outgoing, cx)?;
+        }
+        reg.open_or_create(name, cx)
+    })?;
+    cx.update_global::<CurrentPage, ()>(|current, _| {
+        current.current = Some(page);
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+    use tempfile::TempDir;
+
+    fn make_store(tmp: &TempDir) -> NotesStore {
+        NotesStore::new(tmp.path()).expect("store")
+    }
+
+    #[gpui::test]
+    fn open_or_create_caches_entity_by_name(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        cx.update(|cx| {
+            let mut reg = PageRegistry::new(make_store(&tmp));
+            let a = reg.open_or_create("foo", cx).unwrap();
+            let b = reg.open_or_create("foo", cx).unwrap();
+            assert_eq!(a.entity_id(), b.entity_id());
+        });
+    }
+
+    #[gpui::test]
+    fn save_persists_body_across_registries(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        cx.update(|cx| {
+            let mut reg = PageRegistry::new(NotesStore::new(&root).unwrap());
+            let page = reg.open_or_create("foo", cx).unwrap();
+            page.update(cx, |p, cx| p.set_body_for_test("hello", cx));
+            reg.save(&page, cx).unwrap();
+            assert!(!page.read(cx).dirty());
+        });
+
+        cx.update(|cx| {
+            let mut reg = PageRegistry::new(NotesStore::new(&root).unwrap());
+            let page = reg.open("foo", cx).unwrap();
+            assert_eq!(page.read(cx).body().as_ref(), "hello");
+        });
+    }
+
+    #[gpui::test]
+    fn save_clears_dirty(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        cx.update(|cx| {
+            let mut reg = PageRegistry::new(make_store(&tmp));
+            let page = reg.open_or_create("foo", cx).unwrap();
+            page.update(cx, |p, cx| p.set_body_for_test("x", cx));
+            assert!(page.read(cx).dirty());
+            reg.save(&page, cx).unwrap();
+            assert!(!page.read(cx).dirty());
+        });
+    }
+
+    #[gpui::test]
+    fn save_is_noop_when_not_dirty(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        cx.update(|cx| {
+            let mut reg = PageRegistry::new(make_store(&tmp));
+            let page = reg.open_or_create("foo", cx).unwrap();
+            reg.save(&page, cx).unwrap();
+            assert!(!page.read(cx).dirty());
+        });
+    }
+
+    #[gpui::test]
+    fn set_current_page_autosaves_outgoing(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        cx.update(|cx| {
+            cx.set_global(PageRegistry::new(NotesStore::new(&root).unwrap()));
+            cx.set_global(CurrentPage::default());
+            set_current_page("a", cx).unwrap();
+
+            let page_a = cx.global::<CurrentPage>().get().unwrap().clone();
+            page_a.update(cx, |p, cx| p.set_body_for_test("from-a", cx));
+
+            set_current_page("b", cx).unwrap();
+        });
+
+        cx.update(|cx| {
+            let mut reg = PageRegistry::new(NotesStore::new(&root).unwrap());
+            let page = reg.open("a", cx).unwrap();
+            assert_eq!(page.read(cx).body().as_ref(), "from-a");
+        });
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -107,6 +107,23 @@ impl CurrentPage {
     }
 }
 
+/// Picks the next page name to cycle to after `current`, wrapping at the end.
+/// Returns `None` for an empty `names` slice. If `current` isn't in `names`
+/// (or is `None`), returns the first entry.
+#[must_use]
+pub fn pick_next<'a>(
+    names: &'a [SharedString],
+    current: Option<&SharedString>,
+) -> Option<&'a SharedString> {
+    if names.is_empty() {
+        return None;
+    }
+    let idx = current
+        .and_then(|c| names.iter().position(|n| n == c))
+        .map_or(0, |i| (i + 1) % names.len());
+    Some(&names[idx])
+}
+
 /// Saves the outgoing current page if dirty, opens `name` (creating if missing),
 /// and sets it as the current page.
 ///
@@ -129,6 +146,7 @@ pub fn set_current_page(name: &str, cx: &mut App) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page::PageEvent;
     use gpui::TestAppContext;
     use tempfile::TempDir;
 
@@ -180,6 +198,44 @@ mod tests {
         });
     }
 
+    struct SavedRecorder {
+        count: usize,
+        _sub: gpui::Subscription,
+    }
+
+    impl SavedRecorder {
+        fn new(page: &Entity<crate::page::Page>, cx: &mut gpui::Context<Self>) -> Self {
+            let sub = cx.subscribe(page, |this: &mut Self, _, event: &PageEvent, _| {
+                if matches!(event, PageEvent::Saved) {
+                    this.count += 1;
+                }
+            });
+            Self {
+                count: 0,
+                _sub: sub,
+            }
+        }
+    }
+
+    #[gpui::test]
+    fn save_emits_saved_event(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (recorder, page, mut reg) = cx.update(|cx| {
+            let mut reg = PageRegistry::new(make_store(&tmp));
+            let page = reg.open_or_create("foo", cx).unwrap();
+            let recorder = cx.new(|cx| SavedRecorder::new(&page, cx));
+            (recorder, page, reg)
+        });
+
+        cx.update(|cx| {
+            page.update(cx, |p, cx| p.set_body_for_test("x", cx));
+            reg.save(&page, cx).unwrap();
+        });
+        cx.run_until_parked();
+
+        cx.read(|cx| assert_eq!(recorder.read(cx).count, 1));
+    }
+
     #[gpui::test]
     fn save_is_noop_when_not_dirty(cx: &mut TestAppContext) {
         let tmp = tempfile::tempdir().unwrap();
@@ -189,6 +245,41 @@ mod tests {
             reg.save(&page, cx).unwrap();
             assert!(!page.read(cx).dirty());
         });
+    }
+
+    fn names(items: &[&str]) -> Vec<SharedString> {
+        items
+            .iter()
+            .map(|s| SharedString::from(s.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn pick_next_empty_returns_none() {
+        assert!(pick_next(&[], None).is_none());
+        let current = SharedString::from("foo");
+        assert!(pick_next(&[], Some(&current)).is_none());
+    }
+
+    #[test]
+    fn pick_next_wraps_after_last() {
+        let ns = names(&["a", "b", "c"]);
+        assert_eq!(pick_next(&ns, Some(&ns[2])).unwrap().as_ref(), "a");
+    }
+
+    #[test]
+    fn pick_next_advances_from_current() {
+        let ns = names(&["a", "b", "c"]);
+        assert_eq!(pick_next(&ns, Some(&ns[0])).unwrap().as_ref(), "b");
+        assert_eq!(pick_next(&ns, Some(&ns[1])).unwrap().as_ref(), "c");
+    }
+
+    #[test]
+    fn pick_next_falls_back_to_first_when_current_missing() {
+        let ns = names(&["a", "b"]);
+        let orphan = SharedString::from("zzz");
+        assert_eq!(pick_next(&ns, Some(&orphan)).unwrap().as_ref(), "a");
+        assert_eq!(pick_next(&ns, None).unwrap().as_ref(), "a");
     }
 
     #[gpui::test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -203,6 +203,8 @@ fn decode_page_name(encoded: &str) -> String {
 mod tests {
     use super::{decode_page_name, encode_page_name};
 
+    use rstest::rstest;
+
     #[test]
     fn encode_roundtrips_slash() {
         let name = "Projects/Alpha";
@@ -211,10 +213,12 @@ mod tests {
         assert_eq!(decode_page_name(&encoded), name);
     }
 
-    #[test]
-    fn encode_passes_through_unicode_and_percent() {
-        for name in ["日本語", "a%b", "plain", "a/b/c"] {
-            assert_eq!(decode_page_name(&encode_page_name(name)), name);
-        }
+    #[rstest]
+    #[case::japanese("日本語")]
+    #[case::literal_percent("a%b")]
+    #[case::plain_ascii("plain")]
+    #[case::multiple_slashes("a/b/c")]
+    fn encode_decode_is_identity(#[case] name: &str) {
+        assert_eq!(decode_page_name(&encode_page_name(name)), name);
     }
 }

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -176,6 +176,16 @@ impl TextInput {
         cx.emit(TextInputEvent::Submitted);
     }
 
+    /// Replaces the entire buffer in a headless test. Goes through the same
+    /// `apply_edit` path as real user edits, so subscribers receive a normal
+    /// `Changed` event.
+    #[cfg(test)]
+    pub fn test_replace_all(&mut self, new_content: impl Into<String>, cx: &mut Context<Self>) {
+        let content: String = new_content.into();
+        let end = content.len();
+        self.apply_edit(content, end..end, cx);
+    }
+
     fn on_mouse_down(&mut self, event: &MouseDownEvent, _: &mut Window, cx: &mut Context<Self>) {
         self.is_selecting = true;
         if event.modifiers.shift {

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -78,10 +78,12 @@ impl TextInput {
         }
     }
 
+    #[must_use]
     pub fn content(&self) -> &SharedString {
         &self.content
     }
 
+    #[must_use]
     pub fn selected_range(&self) -> Range<usize> {
         self.selected_range.clone()
     }
@@ -169,6 +171,7 @@ impl TextInput {
         }
     }
 
+    #[allow(clippy::unused_self, clippy::needless_pass_by_ref_mut)]
     fn submit(&mut self, _: &Submit, _: &mut Window, cx: &mut Context<Self>) {
         cx.emit(TextInputEvent::Submitted);
     }
@@ -362,14 +365,16 @@ impl EntityInputHandler for TextInput {
         );
         self.marked_range =
             (!new_text.is_empty()).then(|| range.start..range.start + new_text.len());
-        self.selected_range = new_selected_range_utf16
-            .as_ref()
-            .map(|r| self.range_from_utf16(r))
-            .map(|nr| nr.start + range.start..nr.end + range.end)
-            .unwrap_or_else(|| {
+        self.selected_range = new_selected_range_utf16.as_ref().map_or_else(
+            || {
                 let end = range.start + new_text.len();
                 end..end
-            });
+            },
+            |r| {
+                let nr = self.range_from_utf16(r);
+                nr.start + range.start..nr.end + range.end
+            },
+        );
         self.set_content_and_emit(new_content, cx);
         cx.notify();
     }
@@ -455,7 +460,7 @@ impl Element for TextElement {
         _: Option<&GlobalElementId>,
         _: Option<&InspectorElementId>,
         bounds: Bounds<Pixels>,
-        _: &mut Self::RequestLayoutState,
+        (): &mut Self::RequestLayoutState,
         window: &mut Window,
         cx: &mut App,
     ) -> Self::PrepaintState {
@@ -559,7 +564,7 @@ impl Element for TextElement {
         _: Option<&GlobalElementId>,
         _: Option<&InspectorElementId>,
         bounds: Bounds<Pixels>,
-        _: &mut Self::RequestLayoutState,
+        (): &mut Self::RequestLayoutState,
         prepaint: &mut Self::PrepaintState,
         window: &mut Window,
         cx: &mut App,
@@ -643,6 +648,7 @@ impl Focusable for TextInput {
 
 /// Platform emoji fonts, ordered so the first installed one wins. GPUI
 /// silently skips any family name that isn't present on the system.
+#[must_use]
 pub fn emoji_font_fallbacks() -> FontFallbacks {
     FontFallbacks::from_fonts(vec![
         "Apple Color Emoji".into(),

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -768,67 +768,52 @@ mod tests {
         assert_eq!(next_char_boundary(s, 6), 6);
     }
 
-    #[test]
-    fn backspace_at_start_is_noop() {
-        let (out, sel) = apply_backspace("hello", 0..0);
-        assert_eq!(out, "hello");
-        assert_eq!(sel, 0..0);
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::at_start_is_noop("hello", 0..0, "hello", 0..0)]
+    #[case::removes_prev_char_when_selection_empty("hello", 3..3, "helo", 2..2)]
+    #[case::deletes_selection("hello world", 6..11, "hello ", 6..6)]
+    #[case::respects_utf8_boundary("a🦀b", 5..5, "ab", 1..1)]
+    fn backspace_cases(
+        #[case] content: &str,
+        #[case] selection: Range<usize>,
+        #[case] expected_content: &str,
+        #[case] expected_selection: Range<usize>,
+    ) {
+        let (out, sel) = apply_backspace(content, selection);
+        assert_eq!(out, expected_content);
+        assert_eq!(sel, expected_selection);
     }
 
-    #[test]
-    fn backspace_removes_prev_char_when_selection_empty() {
-        let (out, sel) = apply_backspace("hello", 3..3);
-        assert_eq!(out, "helo");
-        assert_eq!(sel, 2..2);
+    #[rstest]
+    #[case::at_end_is_noop("hello", 5..5, "hello", 5..5)]
+    #[case::removes_next_char_when_selection_empty("hello", 2..2, "helo", 2..2)]
+    #[case::respects_utf8_boundary("a🦀b", 1..1, "ab", 1..1)]
+    fn delete_cases(
+        #[case] content: &str,
+        #[case] selection: Range<usize>,
+        #[case] expected_content: &str,
+        #[case] expected_selection: Range<usize>,
+    ) {
+        let (out, sel) = apply_delete(content, selection);
+        assert_eq!(out, expected_content);
+        assert_eq!(sel, expected_selection);
     }
 
-    #[test]
-    fn backspace_deletes_selection() {
-        let (out, sel) = apply_backspace("hello world", 6..11);
-        assert_eq!(out, "hello ");
-        assert_eq!(sel, 6..6);
-    }
-
-    #[test]
-    fn backspace_respects_utf8_boundary() {
-        let (out, sel) = apply_backspace("a🦀b", 5..5);
-        assert_eq!(out, "ab");
-        assert_eq!(sel, 1..1);
-    }
-
-    #[test]
-    fn delete_at_end_is_noop() {
-        let (out, sel) = apply_delete("hello", 5..5);
-        assert_eq!(out, "hello");
-        assert_eq!(sel, 5..5);
-    }
-
-    #[test]
-    fn delete_removes_next_char_when_selection_empty() {
-        let (out, sel) = apply_delete("hello", 2..2);
-        assert_eq!(out, "helo");
-        assert_eq!(sel, 2..2);
-    }
-
-    #[test]
-    fn delete_respects_utf8_boundary() {
-        let (out, sel) = apply_delete("a🦀b", 1..1);
-        assert_eq!(out, "ab");
-        assert_eq!(sel, 1..1);
-    }
-
-    #[test]
-    fn replace_inserts_at_cursor() {
-        let (out, sel) = apply_replace("helo", 3..3, "l");
-        assert_eq!(out, "hello");
-        assert_eq!(sel, 4..4);
-    }
-
-    #[test]
-    fn replace_overwrites_selection() {
-        let (out, sel) = apply_replace("hello world", 6..11, "there");
-        assert_eq!(out, "hello there");
-        assert_eq!(sel, 11..11);
+    #[rstest]
+    #[case::inserts_at_cursor("helo", 3..3, "l", "hello", 4..4)]
+    #[case::overwrites_selection("hello world", 6..11, "there", "hello there", 11..11)]
+    fn replace_cases(
+        #[case] content: &str,
+        #[case] range: Range<usize>,
+        #[case] new_text: &str,
+        #[case] expected_content: &str,
+        #[case] expected_selection: Range<usize>,
+    ) {
+        let (out, sel) = apply_replace(content, range, new_text);
+        assert_eq!(out, expected_content);
+        assert_eq!(sel, expected_selection);
     }
 
     // Runtime smoke test: `TextInput::new` wires up a focus handle and starts

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -55,11 +55,21 @@ impl EventEmitter<TextInputEvent> for TextInput {}
 
 impl TextInput {
     pub fn new(cx: &mut Context<Self>, placeholder: impl Into<SharedString>) -> Self {
+        Self::with_content(cx, placeholder, SharedString::default())
+    }
+
+    pub fn with_content(
+        cx: &mut Context<Self>,
+        placeholder: impl Into<SharedString>,
+        content: impl Into<SharedString>,
+    ) -> Self {
+        let content: SharedString = content.into();
+        let end = content.len();
         Self {
             focus_handle: cx.focus_handle(),
-            content: SharedString::default(),
+            content,
             placeholder: placeholder.into(),
-            selected_range: 0..0,
+            selected_range: end..end,
             selection_reversed: false,
             marked_range: None,
             last_layout: None,

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -3,6 +3,7 @@ use std::io::ErrorKind;
 
 use chrono::NaiveDate;
 use gpui_notes::store::NotesStore;
+use rstest::rstest;
 use tempfile::TempDir;
 
 fn new_store() -> (TempDir, NotesStore) {
@@ -51,13 +52,16 @@ fn successful_write_leaves_no_tmp_file() {
     );
 }
 
-#[test]
-fn invalid_names_are_rejected() {
+#[rstest]
+#[case::contains_backslash("a\\b")]
+#[case::empty("")]
+#[case::parent_dir("..")]
+#[case::current_dir(".")]
+#[case::hidden_dotfile(".hidden")]
+fn invalid_names_are_rejected(#[case] bad: &str) {
     let (_tmp, store) = new_store();
-    for bad in ["a\\b", "", "..", ".", ".hidden"] {
-        let err = store.write(bad, "x").unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::InvalidInput, "name {bad:?}");
-    }
+    let err = store.write(bad, "x").unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput, "name {bad:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `Page { name, body, input, dirty }` entity with `PageEvent::Saved`; body lives in a per-page `TextInput` that's the source of truth during editing.
- `PageRegistry` + `CurrentPage` app globals; `set_current_page(name, cx)` autosaves the outgoing page before switching.
- Root view renders `name + dirty-indicator + TextInput`, binds `cmd-s` (save) and debug `cmd-p` (cycle through pages from `list()`).
- Opens `scratch` at startup; creates it empty if missing.
- `TextInput::with_content(...)` added so pages can hydrate their input without firing a `Changed` event that would mark them dirty on open.

## Test plan
- [x] `just check` — no new warnings
- [x] `just test` — 34/34 pass, including:
  - `open_or_create_caches_entity_by_name` — same name returns same Entity
  - `save_persists_body_across_registries` — round-trip through fresh registry
  - `save_clears_dirty`, `save_is_noop_when_not_dirty`
  - `set_current_page_autosaves_outgoing` — switching saves dirty outgoing
- [x] Manual GUI verification (launch app → type → cmd-s → quit → relaunch → content persisted → cmd-p cycles) — not run in this environment, no display available.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)