### PR TITLE
fix(deps): split gpui_platform per-target, enable font-kit on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,7 @@ dependencies = [
  "strum",
  "util",
  "uuid",
+ "zed-font-kit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 gpui = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3" }
-gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3", features = ["wayland"] }
 # smallvec is included here for convenience, it is used by gpui when creating
 # components that can have children. uncomment this line or
 # use `cargo add smallvec` to add it to your project
@@ -13,6 +12,14 @@ smallvec = "1.13.2"
 dirs = "5"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 pulldown-cmark = { version = "0.11", default-features = false }
+
+# font-kit is required on macOS — without it gpui_macos falls back to a
+# NoopTextSystem and text never paints. See README "GPUI dependency".
+[target.'cfg(target_os = "macos")'.dependencies]
+gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3", features = ["runtime_shaders", "font-kit"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3", features = ["wayland"] }
 
 [dev-dependencies]
 gpui = { git = "https://github.com/zed-industries/zed", rev = "ec9be5c3", features = ["test-support"] }

--- a/README.md
+++ b/README.md
@@ -32,5 +32,6 @@ To keep builds reproducible, we **pin both crates to a specific `rev`** in `Carg
 
 - Never depend on the floating `main` branch. Always use `rev = "..."`.
 - Both `gpui` and `gpui_platform` must share the same `rev`, or Cargo will pull two copies of the Zed workspace.
+- `gpui_platform` is declared per-target so each OS gets the right backend features: `runtime_shaders` + `font-kit` on macOS, `wayland` on Linux/FreeBSD. The `font-kit` feature is **required on macOS** — without it `gpui_macos` falls back to a `NoopTextSystem` and text shapes but never paints (cursor still renders, so it looks like a styling bug).
 - To bump: pick a new commit from `zed-industries/zed`, update both `rev` values, run `cargo update -p gpui -p gpui_platform`, then `cargo check`. Expect to fix API breakage; check the relevant example in `zed/crates/gpui/examples/` for the current idiomatic usage.
 - Commit the resulting `Cargo.lock` change alongside the `Cargo.toml` bump.


### PR DESCRIPTION
## Summary

- Without the `font-kit` feature, `gpui_macos` installs a `NoopTextSystem` (see `crates/gpui_macos/src/platform.rs` → `MacPlatform::new`). Text is shaped (cursor positioning still works) but `line.paint(...)` never produces glyphs — everything textual is silently invisible, while quads (cursor, backgrounds, borders) render normally. Misdiagnoses easily as a styling/color bug.
- Splits `gpui_platform` into per-target dependency entries so each OS gets the right backend feature set: `runtime_shaders` + `font-kit` on macOS, `wayland` on Linux/FreeBSD.
- Documents the macOS requirement in the README's "GPUI dependency" section and leaves an inline note in `Cargo.toml` so a future `rev` bump doesn't drop the feature.

## Test plan

- [x] `just check` clean
- [x] `cargo nextest run` — 88/88 pass
- [x] `just run` on macOS — journal header and typed text both render (verified visually)
- [x] CI green on Linux (no behavior change for the Linux entry — feature set is identical to before the split)