### PR TITLE
feat(tags): add tag index and navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,6 +2171,7 @@ dependencies = [
  "gpui",
  "gpui_platform",
  "pulldown-cmark",
+ "regex",
  "rstest",
  "smallvec",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ smallvec = "1.13.2"
 dirs = "5"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 pulldown-cmark = { version = "0.11", default-features = false }
+regex = "1"
 
 # font-kit is required on macOS — without it gpui_macos falls back to a
 # NoopTextSystem and text never paints. See README "GPUI dependency".

--- a/src/block_view.rs
+++ b/src/block_view.rs
@@ -14,6 +14,7 @@ use gpui::{
 use crate::block_render::{render_block, theme};
 use crate::outline::BlockId;
 use crate::page::Page;
+use crate::tags::TagExt;
 use crate::text_input::{TextInput, TextInputEvent};
 
 pub struct BlockView {
@@ -139,7 +140,9 @@ impl Render for BlockView {
                     .child(SharedString::from("(empty — click to edit)"))
                     .into_any_element()
             } else {
-                render_block(&text, &[], window, cx)
+                let tag_ext = TagExt;
+                let extensions: [&dyn crate::block_render::InlineExtension; 1] = [&tag_ext];
+                render_block(&text, &extensions, window, cx)
             }
         };
 
@@ -316,6 +319,21 @@ mod tests {
             assert!(
                 input_focus.is_focused(window),
                 "TextInput must hold focus after the click",
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn clicking_tag_chip_does_not_enter_editing(cx: &mut TestAppContext) {
+        let (_page, bv, cx) = mount(cx, "- #tag tag tag\n");
+
+        cx.simulate_click(point(px(8.0), px(10.0)), Modifiers::default());
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert!(
+                !bv.read(cx).is_editing(),
+                "tag mouse-down should not bubble into block editing",
             );
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,6 @@ pub mod outline_view;
 pub mod page;
 pub mod registry;
 pub mod store;
+pub mod tags;
 pub mod text_input;
 pub mod window_frame;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use gpui_notes::journal;
 use gpui_notes::page::Page;
 use gpui_notes::registry::{pick_next, set_current_page, CurrentPage, PageRegistry};
 use gpui_notes::store::NotesStore;
+use gpui_notes::tags::{self, OpenTag, TagIndex, TagSource};
 use gpui_notes::text_input;
 use gpui_notes::window_frame::WindowFrame;
 use gpui_platform::application;
@@ -17,15 +18,20 @@ actions!(gpui_notes, [SavePage, NextPage, JumpToToday]);
 
 struct RootView {
     focus_handle: FocusHandle,
-    _observer: Subscription,
+    active_tag: Option<gpui::SharedString>,
+    _current_observer: Subscription,
+    _tag_observer: Subscription,
 }
 
 impl RootView {
     fn new(cx: &mut Context<Self>) -> Self {
-        let observer = cx.observe_global::<CurrentPage>(|_, cx| cx.notify());
+        let current_observer = cx.observe_global::<CurrentPage>(|_, cx| cx.notify());
+        let tag_observer = cx.observe_global::<TagIndex>(|_, cx| cx.notify());
         Self {
             focus_handle: cx.focus_handle(),
-            _observer: observer,
+            active_tag: None,
+            _current_observer: current_observer,
+            _tag_observer: tag_observer,
         }
     }
 
@@ -58,6 +64,7 @@ impl RootView {
             eprintln!("open today's journal failed: {err}");
             return;
         }
+        self.active_tag = None;
         self.focus_current(window, cx);
     }
 
@@ -80,7 +87,78 @@ impl RootView {
             eprintln!("open {next:?} failed: {err}");
             return;
         }
+        self.active_tag = None;
         self.focus_current(window, cx);
+    }
+
+    fn open_tag(&mut self, action: &OpenTag, _: &mut Window, cx: &mut Context<Self>) {
+        self.reindex_current_page(cx);
+        self.active_tag = Some(action.name.clone());
+        cx.notify();
+    }
+
+    fn reindex_current_page(&self, cx: &mut Context<Self>) {
+        let Some(page) = cx.global::<CurrentPage>().get().cloned() else {
+            return;
+        };
+        let source =
+            cx.update_global::<PageRegistry, TagSource>(|reg, cx| reg.source_for_page(&page, cx));
+        tags::reindex_global_for_page(&page, source, cx);
+    }
+
+    fn open_tag_hit(&mut self, source: &TagSource, window: &mut Window, cx: &mut Context<Self>) {
+        let result = match source {
+            TagSource::Page(name) => set_current_page(name.as_ref(), cx).map(|_| ()),
+            TagSource::Journal(date) => journal::open_for_date(*date, cx).map(|_| ()),
+        };
+        if let Err(err) = result {
+            eprintln!("open tag result failed: {err}");
+            return;
+        }
+        self.active_tag = None;
+        self.focus_current(window, cx);
+        cx.notify();
+    }
+
+    fn render_tag_results(
+        &mut self,
+        tag: &gpui::SharedString,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let hits = cx.global::<TagIndex>().blocks_for_tag(tag.as_ref());
+        if hits.is_empty() {
+            return div()
+                .flex_1()
+                .text_color(rgb(0x999999))
+                .child("No blocks found.")
+                .into_any_element();
+        }
+
+        let mut list = div().flex().flex_col().gap_1().flex_1();
+        for hit in hits {
+            let source = hit.source.clone();
+            let label = tags::source_label(&hit.source);
+            let preview = tags::truncated_preview(hit.preview.as_ref());
+            list = list.child(
+                div()
+                    .id(gpui::ElementId::Name(gpui::SharedString::from(format!(
+                        "tag-hit-{:?}",
+                        hit.block_id
+                    ))))
+                    .cursor_pointer()
+                    .rounded_sm()
+                    .px_2()
+                    .py_1()
+                    .min_h(px(28.0))
+                    .text_color(rgb(0xdddddd))
+                    .hover(|style| style.bg(rgb(0x2a2a2a)))
+                    .child(format!("{label}: {preview}"))
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.open_tag_hit(&source, window, cx);
+                    })),
+            );
+        }
+        list.into_any_element()
     }
 }
 
@@ -100,6 +178,7 @@ impl Render for RootView {
             .on_action(cx.listener(Self::save_current))
             .on_action(cx.listener(Self::next_page))
             .on_action(cx.listener(Self::jump_to_today))
+            .on_action(cx.listener(Self::open_tag))
             .flex()
             .flex_col()
             .size_full()
@@ -116,19 +195,27 @@ impl Render for RootView {
             let p = page.read(cx);
             (p.name().clone(), p.dirty(), p.view().clone())
         };
-        let header = if dirty {
+        let active_tag = self.active_tag.clone();
+        let header = if let Some(tag) = active_tag.as_ref() {
+            format!("#{}", tag.as_ref())
+        } else if dirty {
             format!("{name} •")
         } else {
             name.to_string()
         };
 
-        root.child(
+        let root = root.child(
             div()
                 .text_color(rgb(0xcccccc))
                 .text_size(px(14.))
                 .child(header),
-        )
-        .child(view)
+        );
+
+        if let Some(tag) = active_tag {
+            root.child(self.render_tag_results(&tag, cx))
+        } else {
+            root.child(view)
+        }
     }
 }
 
@@ -148,6 +235,8 @@ fn main() {
 
         let root_dir = NotesStore::default_root().expect("resolve notes root");
         let store = NotesStore::new(root_dir).expect("init notes store");
+        let tag_index = TagIndex::rebuild_from(&store).expect("index tags");
+        cx.set_global(tag_index);
         cx.set_global(PageRegistry::new(store));
         cx.set_global(CurrentPage::default());
         journal::open_today(cx).expect("open today's journal");
@@ -167,4 +256,70 @@ fn main() {
         )
         .unwrap();
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{point, Modifiers, TestAppContext, VisualTestContext};
+    use tempfile::TempDir;
+
+    fn mount_root<'a>(
+        cx: &'a mut TestAppContext,
+        tmp: &TempDir,
+    ) -> (Entity<RootView>, &'a mut VisualTestContext) {
+        let root_dir = tmp.path().to_path_buf();
+        let (root, vcx) = cx.add_window_view(move |_window, cx| {
+            text_input::bind_keys(cx);
+            let store = NotesStore::new(&root_dir).unwrap();
+            store.write("Home", "- home\n").unwrap();
+            store.write("Tagged", "- has #todo\n").unwrap();
+            cx.set_global(TagIndex::rebuild_from(&store).unwrap());
+            cx.set_global(PageRegistry::new(store));
+            cx.set_global(CurrentPage::default());
+            set_current_page("Home", cx).unwrap();
+            RootView::new(cx)
+        });
+        vcx.update(|window, cx| {
+            window.activate_window();
+            root.update(cx, |view, cx| view.focus_current(window, cx));
+        });
+        vcx.run_until_parked();
+        (root, vcx)
+    }
+
+    #[gpui::test]
+    fn tag_results_row_click_opens_page(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+
+        cx.update(|window, cx| {
+            root.update(cx, |root, cx| {
+                root.open_tag(
+                    &OpenTag {
+                        name: "todo".into(),
+                    },
+                    window,
+                    cx,
+                );
+            });
+        });
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert_eq!(
+                root.read(cx).active_tag.as_ref().map(AsRef::as_ref),
+                Some("todo"),
+            );
+        });
+
+        cx.simulate_click(point(px(24.0), px(50.0)), Modifiers::default());
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let current = cx.global::<CurrentPage>().get().unwrap();
+            assert_eq!(current.read(cx).name().as_ref(), "Tagged");
+            assert!(root.read(cx).active_tag.is_none());
+        });
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,23 +92,23 @@ impl RootView {
     }
 
     fn open_tag(&mut self, action: &OpenTag, _: &mut Window, cx: &mut Context<Self>) {
-        self.reindex_current_page(cx);
+        Self::reindex_current_page(cx);
         self.active_tag = Some(action.name.clone());
         cx.notify();
     }
 
-    fn reindex_current_page(&self, cx: &mut Context<Self>) {
+    fn reindex_current_page(cx: &mut Context<Self>) {
         let Some(page) = cx.global::<CurrentPage>().get().cloned() else {
             return;
         };
         let source =
             cx.update_global::<PageRegistry, TagSource>(|reg, cx| reg.source_for_page(&page, cx));
-        tags::reindex_global_for_page(&page, source, cx);
+        tags::reindex_global_for_page(&page, &source, cx);
     }
 
     fn open_tag_hit(&mut self, source: &TagSource, window: &mut Window, cx: &mut Context<Self>) {
         let result = match source {
-            TagSource::Page(name) => set_current_page(name.as_ref(), cx).map(|_| ()),
+            TagSource::Page(name) => set_current_page(name.as_ref(), cx),
             TagSource::Journal(date) => journal::open_for_date(*date, cx).map(|_| ()),
         };
         if let Err(err) = result {
@@ -120,11 +120,7 @@ impl RootView {
         cx.notify();
     }
 
-    fn render_tag_results(
-        &mut self,
-        tag: &gpui::SharedString,
-        cx: &mut Context<Self>,
-    ) -> gpui::AnyElement {
+    fn render_tag_results(tag: &gpui::SharedString, cx: &mut Context<Self>) -> gpui::AnyElement {
         let hits = cx.global::<TagIndex>().blocks_for_tag(tag.as_ref());
         if hits.is_empty() {
             return div()
@@ -212,7 +208,7 @@ impl Render for RootView {
         );
 
         if let Some(tag) = active_tag {
-            root.child(self.render_tag_results(&tag, cx))
+            root.child(Self::render_tag_results(&tag, cx))
         } else {
             root.child(view)
         }

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct BlockId(u64);
 
 static NEXT_BLOCK_ID: AtomicU64 = AtomicU64::new(1);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,11 +6,21 @@ use gpui::{App, AppContext, BorrowAppContext, Entity, Global, SharedString};
 
 use crate::page::Page;
 use crate::store::NotesStore;
+use crate::tags::{self, TagSource};
 
 #[derive(Clone, Copy, Debug)]
 enum PageKind {
     Page,
     Journal(NaiveDate),
+}
+
+impl PageKind {
+    fn source(self, key: &SharedString) -> TagSource {
+        match self {
+            Self::Page => TagSource::Page(key.clone()),
+            Self::Journal(date) => TagSource::Journal(date),
+        }
+    }
 }
 
 struct OpenPage {
@@ -129,7 +139,18 @@ impl PageRegistry {
             PageKind::Journal(date) => self.store.write_journal(date, &body)?,
         }
         page.update(cx, Page::mark_saved);
+        let source = kind.source(&name);
+        tags::reindex_global_for_page(page, source, cx);
         Ok(())
+    }
+
+    #[must_use]
+    pub fn source_for_page(&self, page: &Entity<Page>, cx: &App) -> TagSource {
+        let name = page.read(cx).name().clone();
+        self.open.get(&name).map_or_else(
+            || TagSource::Page(name.clone()),
+            |entry| entry.kind.source(&name),
+        )
     }
 
     fn insert(
@@ -139,6 +160,7 @@ impl PageRegistry {
         kind: PageKind,
         cx: &mut App,
     ) -> Entity<Page> {
+        let source = kind.source(&key);
         let page = cx.new(|cx| Page::new(key.clone(), body, cx));
         self.open.insert(
             key,
@@ -147,6 +169,7 @@ impl PageRegistry {
                 kind,
             },
         );
+        tags::reindex_global_for_page(&page, source, cx);
         page
     }
 }
@@ -209,6 +232,7 @@ pub fn set_current_page(name: &str, cx: &mut App) -> io::Result<()> {
 mod tests {
     use super::*;
     use crate::page::PageEvent;
+    use crate::tags::TagIndex;
     use gpui::TestAppContext;
     use tempfile::TempDir;
 
@@ -306,6 +330,30 @@ mod tests {
             let page = reg.open_or_create("foo", cx).unwrap();
             reg.save(&page, cx).unwrap();
             assert!(!page.read(cx).dirty());
+        });
+    }
+
+    #[gpui::test]
+    fn open_and_save_refresh_tag_index(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        cx.update(|cx| {
+            cx.set_global(TagIndex::default());
+            let store = NotesStore::new(&root).unwrap();
+            store.write("foo", "- old #stale\n").unwrap();
+            let mut reg = PageRegistry::new(store);
+
+            let page = reg.open("foo", cx).unwrap();
+            assert_eq!(cx.global::<TagIndex>().blocks_for_tag("stale").len(), 1);
+
+            let first = page.read(cx).outline().first_block_id().unwrap();
+            page.update(cx, |p, cx| p.set_block_text(first, "new #fresh", cx));
+            reg.save(&page, cx).unwrap();
+
+            let index = cx.global::<TagIndex>();
+            assert!(index.blocks_for_tag("stale").is_empty());
+            assert_eq!(index.blocks_for_tag("fresh").len(), 1);
         });
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -140,7 +140,7 @@ impl PageRegistry {
         }
         page.update(cx, Page::mark_saved);
         let source = kind.source(&name);
-        tags::reindex_global_for_page(page, source, cx);
+        tags::reindex_global_for_page(page, &source, cx);
         Ok(())
     }
 
@@ -169,7 +169,7 @@ impl PageRegistry {
                 kind,
             },
         );
-        tags::reindex_global_for_page(&page, source, cx);
+        tags::reindex_global_for_page(&page, &source, cx);
         page
     }
 }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -98,8 +98,8 @@ impl TagIndex {
         summaries
     }
 
-    pub fn reindex_page(&mut self, source: TagSource, outline: &Outline) {
-        self.remove_source(&source);
+    pub fn reindex_page(&mut self, source: &TagSource, outline: &Outline) {
+        self.remove_source(source);
 
         for block in all_blocks(&outline.roots) {
             let tags = tags_in_text(&block.text);
@@ -133,12 +133,12 @@ impl TagIndex {
         for name in store.list()? {
             let body = store.read(&name)?;
             let outline = Outline::parse(&body);
-            index.reindex_page(TagSource::Page(SharedString::from(name)), &outline);
+            index.reindex_page(&TagSource::Page(SharedString::from(name)), &outline);
         }
         for date in store.list_journals()? {
             let body = store.read_journal(date)?;
             let outline = Outline::parse(&body);
-            index.reindex_page(TagSource::Journal(date), &outline);
+            index.reindex_page(&TagSource::Journal(date), &outline);
         }
         Ok(index)
     }
@@ -208,7 +208,7 @@ impl InlineExtension for TagExt {
     }
 }
 
-pub fn reindex_global_for_page(page: &gpui::Entity<Page>, source: TagSource, cx: &mut App) {
+pub fn reindex_global_for_page(page: &gpui::Entity<Page>, source: &TagSource, cx: &mut App) {
     if !cx.has_global::<TagIndex>() {
         return;
     }
@@ -309,19 +309,20 @@ mod tests {
             .collect()
     }
 
+    fn count_inlines(nodes: &[InlineNode]) -> usize {
+        nodes
+            .iter()
+            .map(|node| match node {
+                InlineNode::Extension(_) => 1,
+                InlineNode::Link { children, .. } => count_inlines(children),
+                _ => 0,
+            })
+            .sum()
+    }
+
     fn extension_count(text: &str) -> usize {
         let ext = TagExt;
         let extensions: [&dyn InlineExtension; 1] = [&ext];
-        fn count_inlines(nodes: &[InlineNode]) -> usize {
-            nodes
-                .iter()
-                .map(|node| match node {
-                    InlineNode::Extension(_) => 1,
-                    InlineNode::Link { children, .. } => count_inlines(children),
-                    _ => 0,
-                })
-                .sum()
-        }
         lower(text, &extensions)
             .iter()
             .map(|block| match block {
@@ -398,11 +399,11 @@ mod tests {
         let mut index = TagIndex::default();
         let source = TagSource::Page("PageA".into());
         let old = Outline::parse("- old #gone\n- keep #stay\n");
-        index.reindex_page(source.clone(), &old);
+        index.reindex_page(&source, &old);
         assert_eq!(index.blocks_for_tag("gone").len(), 1);
 
         let new = Outline::parse("- keep #stay\n");
-        index.reindex_page(source, &new);
+        index.reindex_page(&source, &new);
         assert!(index.blocks_for_tag("gone").is_empty());
         assert_eq!(index.blocks_for_tag("stay").len(), 1);
     }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,0 +1,488 @@
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::LazyLock;
+
+use chrono::NaiveDate;
+use gpui::{
+    div, px, App, BorrowAppContext, ElementId, Global, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, SharedString, StatefulInteractiveElement, Styled, Window,
+};
+use regex::Regex;
+
+use crate::block_render::{
+    lower, theme, BlockNode, ExtensionMatch, ExtensionNode, InlineExtension, InlineNode,
+};
+use crate::outline::{Block, BlockId, Outline};
+use crate::page::Page;
+use crate::store::NotesStore;
+
+static TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:^|[\s(,.:;!?\-])#([A-Za-z0-9_][A-Za-z0-9_\-/]*)").expect("tag regex is valid")
+});
+
+#[derive(Clone, Debug, PartialEq, gpui::Action)]
+#[action(namespace = gpui_notes, no_json)]
+pub struct OpenTag {
+    pub name: SharedString,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TagSource {
+    Page(SharedString),
+    Journal(NaiveDate),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TagHit {
+    pub source: TagSource,
+    pub block_id: BlockId,
+    pub preview: SharedString,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TagSummary {
+    pub display: SharedString,
+    pub count: usize,
+}
+
+#[derive(Clone, Debug)]
+struct IndexedHit {
+    hit: TagHit,
+    display: SharedString,
+    order: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TagEntry {
+    hits: BTreeMap<(TagSource, BlockId), IndexedHit>,
+}
+
+#[derive(Default)]
+pub struct TagIndex {
+    entries: BTreeMap<String, TagEntry>,
+    next_order: u64,
+}
+
+impl Global for TagIndex {}
+
+impl TagIndex {
+    #[must_use]
+    pub fn blocks_for_tag(&self, tag: &str) -> Vec<TagHit> {
+        let key = tag_key(tag);
+        let Some(entry) = self.entries.get(&key) else {
+            return Vec::new();
+        };
+        let mut hits: Vec<&IndexedHit> = entry.hits.values().collect();
+        hits.sort_by_key(|hit| hit.order);
+        hits.into_iter().map(|hit| hit.hit.clone()).collect()
+    }
+
+    #[must_use]
+    pub fn all_tags(&self) -> Vec<TagSummary> {
+        let mut summaries: Vec<TagSummary> = self
+            .entries
+            .values()
+            .filter_map(|entry| {
+                let display = entry
+                    .hits
+                    .values()
+                    .min_by_key(|hit| hit.order)
+                    .map(|hit| hit.display.clone())?;
+                Some(TagSummary {
+                    display,
+                    count: entry.hits.len(),
+                })
+            })
+            .collect();
+        summaries.sort_by_key(|summary| summary.display.to_ascii_lowercase());
+        summaries
+    }
+
+    pub fn reindex_page(&mut self, source: TagSource, outline: &Outline) {
+        self.remove_source(&source);
+
+        for block in all_blocks(&outline.roots) {
+            let tags = tags_in_text(&block.text);
+            if tags.is_empty() {
+                continue;
+            }
+            for (key, display) in tags {
+                let entry = self.entries.entry(key).or_default();
+                let hit_key = (source.clone(), block.id);
+                entry.hits.entry(hit_key).or_insert_with(|| {
+                    let order = self.next_order;
+                    self.next_order += 1;
+                    IndexedHit {
+                        hit: TagHit {
+                            source: source.clone(),
+                            block_id: block.id,
+                            preview: SharedString::from(block.text.clone()),
+                        },
+                        display,
+                        order,
+                    }
+                });
+            }
+        }
+    }
+
+    /// # Errors
+    /// Returns the first I/O error from listing or reading pages/journals.
+    pub fn rebuild_from(store: &NotesStore) -> io::Result<Self> {
+        let mut index = Self::default();
+        for name in store.list()? {
+            let body = store.read(&name)?;
+            let outline = Outline::parse(&body);
+            index.reindex_page(TagSource::Page(SharedString::from(name)), &outline);
+        }
+        for date in store.list_journals()? {
+            let body = store.read_journal(date)?;
+            let outline = Outline::parse(&body);
+            index.reindex_page(TagSource::Journal(date), &outline);
+        }
+        Ok(index)
+    }
+
+    fn remove_source(&mut self, source: &TagSource) {
+        self.entries.retain(|_, entry| {
+            entry.hits.retain(|(hit_source, _), _| hit_source != source);
+            !entry.hits.is_empty()
+        });
+    }
+}
+
+pub struct TagExt;
+
+impl InlineExtension for TagExt {
+    fn extract(&self, text: &str) -> Vec<ExtensionMatch> {
+        TAG_RE
+            .captures_iter(text)
+            .filter_map(|captures| {
+                let body = captures.get(1)?;
+                let start = body.start().checked_sub(1)?;
+                Some(ExtensionMatch {
+                    range: start..body.end(),
+                    kind: "tag".into(),
+                })
+            })
+            .collect()
+    }
+
+    fn render(
+        &self,
+        node: &ExtensionNode,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> gpui::AnyElement {
+        let display = node.source.trim_start_matches('#').to_string();
+        let tag_name = SharedString::from(display.clone());
+        div()
+            .id(ElementId::Name(SharedString::from(format!(
+                "tag-{display}"
+            ))))
+            .cursor_pointer()
+            .bg(theme::bg_subtle())
+            .text_color(theme::accent())
+            .border_1()
+            .border_color(theme::accent())
+            .rounded_sm()
+            .px_1()
+            .py_0p5()
+            .min_h(px(18.0))
+            .min_w(px(24.0))
+            .child(SharedString::from(display))
+            .on_mouse_down(MouseButton::Left, |_, window, cx| {
+                window.prevent_default();
+                cx.stop_propagation();
+            })
+            .on_click(move |_, window, cx| {
+                cx.stop_propagation();
+                window.dispatch_action(
+                    Box::new(OpenTag {
+                        name: tag_name.clone(),
+                    }),
+                    cx,
+                );
+            })
+            .into_any_element()
+    }
+}
+
+pub fn reindex_global_for_page(page: &gpui::Entity<Page>, source: TagSource, cx: &mut App) {
+    if !cx.has_global::<TagIndex>() {
+        return;
+    }
+    let outline = page.read(cx).outline().clone();
+    cx.update_global::<TagIndex, ()>(|index, _| {
+        index.reindex_page(source, &outline);
+    });
+}
+
+#[must_use]
+pub fn tag_key(tag: &str) -> String {
+    tag.trim_start_matches('#').to_ascii_lowercase()
+}
+
+#[must_use]
+pub fn source_label(source: &TagSource) -> SharedString {
+    match source {
+        TagSource::Page(name) => name.clone(),
+        TagSource::Journal(date) => SharedString::from(date.format("%Y-%m-%d").to_string()),
+    }
+}
+
+#[must_use]
+pub fn truncated_preview(preview: &str) -> String {
+    let mut out: String = preview.chars().take(80).collect();
+    if preview.chars().count() > 80 {
+        out.push_str("...");
+    }
+    out
+}
+
+fn all_blocks(blocks: &[Block]) -> Vec<&Block> {
+    fn walk<'a>(out: &mut Vec<&'a Block>, blocks: &'a [Block]) {
+        for block in blocks {
+            out.push(block);
+            walk(out, &block.children);
+        }
+    }
+    let mut out = Vec::new();
+    walk(&mut out, blocks);
+    out
+}
+
+fn tags_in_text(text: &str) -> BTreeMap<String, SharedString> {
+    let ext = TagExt;
+    let extensions: [&dyn InlineExtension; 1] = [&ext];
+    let blocks = lower(text, &extensions);
+    let mut tags = BTreeMap::new();
+    for block in blocks {
+        collect_tags_from_block(&block, &mut tags);
+    }
+    tags
+}
+
+fn collect_tags_from_block(block: &BlockNode, out: &mut BTreeMap<String, SharedString>) {
+    match block {
+        BlockNode::Paragraph(children) | BlockNode::Heading { children, .. } => {
+            collect_tags_from_inlines(children, out);
+        }
+        BlockNode::Quote(children) => {
+            for child in children {
+                collect_tags_from_block(child, out);
+            }
+        }
+        BlockNode::CodeBlock { .. } => {}
+    }
+}
+
+fn collect_tags_from_inlines(nodes: &[InlineNode], out: &mut BTreeMap<String, SharedString>) {
+    for node in nodes {
+        match node {
+            InlineNode::Extension(node) if node.kind.as_ref() == "tag" => {
+                let display = node.source.trim_start_matches('#').to_string();
+                out.entry(display.to_ascii_lowercase())
+                    .or_insert_with(|| SharedString::from(display));
+            }
+            InlineNode::Link { children, .. } => collect_tags_from_inlines(children, out),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_render::{lower, render_block, BlockNode};
+    use gpui::{
+        point, Context, Entity, FocusHandle, Focusable, Modifiers, Render, TestAppContext,
+        VisualTestContext,
+    };
+    use tempfile::TempDir;
+
+    fn ranges(text: &str) -> Vec<(std::ops::Range<usize>, String)> {
+        TagExt
+            .extract(text)
+            .into_iter()
+            .map(|m| (m.range.clone(), text[m.range].to_string()))
+            .collect()
+    }
+
+    fn extension_count(text: &str) -> usize {
+        let ext = TagExt;
+        let extensions: [&dyn InlineExtension; 1] = [&ext];
+        fn count_inlines(nodes: &[InlineNode]) -> usize {
+            nodes
+                .iter()
+                .map(|node| match node {
+                    InlineNode::Extension(_) => 1,
+                    InlineNode::Link { children, .. } => count_inlines(children),
+                    _ => 0,
+                })
+                .sum()
+        }
+        lower(text, &extensions)
+            .iter()
+            .map(|block| match block {
+                BlockNode::Paragraph(children) | BlockNode::Heading { children, .. } => {
+                    count_inlines(children)
+                }
+                BlockNode::Quote(_) | BlockNode::CodeBlock { .. } => 0,
+            })
+            .sum()
+    }
+
+    #[test]
+    fn tag_ext_extracts_expected_tags() {
+        assert_eq!(ranges("#rust"), vec![(0..5, "#rust".into())]);
+        assert_eq!(
+            ranges("see #proj/sub-task"),
+            vec![(4..18, "#proj/sub-task".into())],
+        );
+        assert_eq!(
+            ranges("foo#bar"),
+            Vec::<(std::ops::Range<usize>, String)>::new()
+        );
+        assert_eq!(ranges("#"), Vec::<(std::ops::Range<usize>, String)>::new());
+        assert_eq!(
+            ranges("#a #b,#c"),
+            vec![
+                (0..2, "#a".into()),
+                (3..5, "#b".into()),
+                (6..8, "#c".into()),
+            ],
+        );
+        assert_eq!(ranges("##"), Vec::<(std::ops::Range<usize>, String)>::new());
+        assert_eq!(ranges("é #tag"), vec![(3..7, "#tag".into())]);
+    }
+
+    #[test]
+    fn lower_does_not_extract_tags_from_code_or_urls() {
+        assert_eq!(extension_count("see `#code`"), 0);
+        assert_eq!(extension_count("```txt\n#code\n```\n"), 0);
+        assert_eq!(extension_count("# heading"), 0);
+        assert_eq!(extension_count("https://example.test/#frag"), 0);
+    }
+
+    #[test]
+    fn index_rebuilds_pages_and_journals_case_insensitively() {
+        let tmp = TempDir::new().unwrap();
+        let store = NotesStore::new(tmp.path()).unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 18).unwrap();
+        store
+            .write("PageA", "- one #Rust #rust\n- two #work\n")
+            .unwrap();
+        store.write_journal(date, "- today #RUST\n").unwrap();
+
+        let index = TagIndex::rebuild_from(&store).unwrap();
+        let rust = index.blocks_for_tag("#rust");
+        assert_eq!(rust.len(), 2, "duplicate tags in one block count once");
+        assert_eq!(index.blocks_for_tag("RUST"), rust);
+
+        let summaries = index.all_tags();
+        assert_eq!(
+            summaries
+                .iter()
+                .find(|summary| summary.display.as_ref() == "Rust")
+                .map(|summary| summary.count),
+            Some(2),
+        );
+        assert!(rust
+            .iter()
+            .any(|hit| matches!(hit.source, TagSource::Journal(d) if d == date)));
+    }
+
+    #[test]
+    fn reindex_removes_stale_tags() {
+        let mut index = TagIndex::default();
+        let source = TagSource::Page("PageA".into());
+        let old = Outline::parse("- old #gone\n- keep #stay\n");
+        index.reindex_page(source.clone(), &old);
+        assert_eq!(index.blocks_for_tag("gone").len(), 1);
+
+        let new = Outline::parse("- keep #stay\n");
+        index.reindex_page(source, &new);
+        assert!(index.blocks_for_tag("gone").is_empty());
+        assert_eq!(index.blocks_for_tag("stay").len(), 1);
+    }
+
+    #[derive(Default)]
+    struct OpenTagRecorder {
+        opened: Option<SharedString>,
+    }
+    impl Global for OpenTagRecorder {}
+
+    struct HostView {
+        text: SharedString,
+        focus_handle: FocusHandle,
+    }
+
+    impl HostView {
+        fn new(text: SharedString, cx: &mut Context<Self>) -> Self {
+            Self {
+                text,
+                focus_handle: cx.focus_handle(),
+            }
+        }
+    }
+
+    impl Focusable for HostView {
+        fn focus_handle(&self, _: &App) -> FocusHandle {
+            self.focus_handle.clone()
+        }
+    }
+
+    impl Render for HostView {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            let tag_ext = TagExt;
+            let extensions: [&dyn InlineExtension; 1] = [&tag_ext];
+            div()
+                .track_focus(&self.focus_handle)
+                .key_context("TagHost")
+                .on_action(|action: &OpenTag, _window, cx| {
+                    cx.update_global::<OpenTagRecorder, _>(|recorder, _| {
+                        recorder.opened = Some(action.name.clone());
+                    });
+                })
+                .size_full()
+                .child(render_block(&self.text, &extensions, window, cx))
+        }
+    }
+
+    fn mount_host<'a>(
+        cx: &'a mut TestAppContext,
+        text: &str,
+    ) -> (Entity<HostView>, &'a mut VisualTestContext) {
+        let text = SharedString::from(text.to_string());
+        let (view, vcx) = cx.add_window_view(move |_window, cx| {
+            cx.set_global(OpenTagRecorder::default());
+            HostView::new(text, cx)
+        });
+        vcx.update(|window, cx| {
+            window.activate_window();
+            let handle = view.read(cx).focus_handle.clone();
+            window.focus(&handle, cx);
+        });
+        vcx.run_until_parked();
+        (view, vcx)
+    }
+
+    #[gpui::test]
+    fn clicking_rendered_tag_dispatches_open_tag(cx: &mut TestAppContext) {
+        let (_view, cx) = mount_host(cx, "#alpha alpha alpha");
+
+        cx.simulate_click(point(px(8.0), px(10.0)), Modifiers::default());
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert_eq!(
+                cx.global::<OpenTagRecorder>()
+                    .opened
+                    .as_ref()
+                    .map(AsRef::as_ref),
+                Some("alpha"),
+            );
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Recognizes `#tag` tokens in block text, renders them as styled chips, and builds a `TagIndex` global for filtering / navigation.
- New `src/tags.rs` with `TagExt: InlineExtension`, `TagIndex`, and a `TagView`; clicking a tag dispatches `OpenTag`.
- Wires the extension into block rendering and registers the global + action in `main.rs`.

## Test plan
- [x] `just check` (clippy --all-targets -D warnings)
- [x] `cargo nextest run` — 111 passed, 0 failed (includes new `tags::tests::*` cases covering extraction, exclusions in code/URLs, reindex, and click → OpenTag dispatch)
- [x] Manual: launch app, type `#foo` in a block, confirm chip renders and clicking opens the tag view

Closes #11