### PR TITLE
refactor(state): explicit enums for overlay/block modes with exhaustive transition tests

### DIFF
--- a/src/block_view.rs
+++ b/src/block_view.rs
@@ -29,18 +29,28 @@ pub enum BlockViewEvent {
 
 impl EventEmitter<BlockViewEvent> for BlockView {}
 
+/// The two display modes for a single block. `Editing` carries the live
+/// `TextInput` and the two subscriptions that drive the exit transitions
+/// (blur and Escape), so every edit cycle replaces them as a unit — there is
+/// no way to have a dangling subscription without an input or vice versa.
+pub enum BlockMode {
+    Viewing,
+    Editing {
+        input: Entity<TextInput>,
+        /// Drops on edit exit. Fires `end_editing` when focus leaves the input.
+        _on_blur: Subscription,
+        /// Drops on edit exit. Fires on `TextInputEvent::Cancelled` (Escape)
+        /// because the blur listener can lag a frame.
+        _on_event: Subscription,
+    },
+}
+
 pub struct BlockView {
     block_id: BlockId,
     page: Entity<Page>,
     focus_handle: FocusHandle,
-    input: Option<Entity<TextInput>>,
+    mode: BlockMode,
     _on_focus: Subscription,
-    /// Reset every edit cycle — subscribes to the *current* `TextInput`'s blur.
-    on_input_blur: Option<Subscription>,
-    /// Reset every edit cycle — subscribes to the current `TextInput`'s events
-    /// (used to exit editing on Escape, since the blur listener can lag a
-    /// frame and leave the input visually mounted until the next redraw).
-    on_input_event: Option<Subscription>,
     _page_sub: Subscription,
 }
 
@@ -63,10 +73,8 @@ impl BlockView {
             block_id,
             page,
             focus_handle,
-            input: None,
+            mode: BlockMode::Viewing,
             _on_focus: on_focus,
-            on_input_blur: None,
-            on_input_event: None,
             _page_sub: page_sub,
         }
     }
@@ -77,12 +85,17 @@ impl BlockView {
     }
 
     #[must_use]
+    pub fn mode(&self) -> &BlockMode {
+        &self.mode
+    }
+
+    #[must_use]
     pub fn is_editing(&self) -> bool {
-        self.input.is_some()
+        matches!(self.mode, BlockMode::Editing { .. })
     }
 
     fn begin_editing(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.input.is_some() {
+        if matches!(self.mode, BlockMode::Editing { .. }) {
             return;
         }
         let text = self
@@ -107,9 +120,11 @@ impl BlockView {
             TextInputEvent::Changed(_) => {}
         });
         window.focus(&input_focus, cx);
-        self.input = Some(input);
-        self.on_input_blur = Some(on_blur);
-        self.on_input_event = Some(on_event);
+        self.mode = BlockMode::Editing {
+            input,
+            _on_blur: on_blur,
+            _on_event: on_event,
+        };
         cx.notify();
     }
 
@@ -117,12 +132,21 @@ impl BlockView {
         self.end_editing_inner(cx);
     }
 
+    /// Take the live `TextInput` from `mode` (transitioning to `Viewing`) and
+    /// return it. Drops the blur/event subscriptions atomically.
+    fn take_input_on_exit(&mut self) -> Option<Entity<TextInput>> {
+        match std::mem::replace(&mut self.mode, BlockMode::Viewing) {
+            BlockMode::Editing { input, .. } => Some(input),
+            BlockMode::Viewing => None,
+        }
+    }
+
     /// Flush the in-progress edit, insert an empty sibling immediately after
     /// this block, and ask the parent view to focus the new block. The new
     /// block's text starts empty regardless of where the caret was — splitting
     /// at the caret is a follow-up (see issue #31).
     fn insert_sibling_below(&mut self, cx: &mut Context<Self>) {
-        let Some(input) = self.input.take() else {
+        let Some(input) = self.take_input_on_exit() else {
             return;
         };
         let text = input.read(cx).content().to_string();
@@ -131,8 +155,6 @@ impl BlockView {
             p.set_block_text(block_id, text, cx);
             p.insert_block_after(block_id, "", cx)
         });
-        self.on_input_blur = None;
-        self.on_input_event = None;
         cx.notify();
         if let Some(new_id) = new_id {
             cx.emit(BlockViewEvent::FocusRequested(new_id));
@@ -140,15 +162,13 @@ impl BlockView {
     }
 
     fn end_editing_inner(&mut self, cx: &mut Context<Self>) {
-        let Some(input) = self.input.take() else {
+        let Some(input) = self.take_input_on_exit() else {
             return;
         };
         let text = input.read(cx).content().to_string();
         let block_id = self.block_id;
         self.page
             .update(cx, |p, cx| p.set_block_text(block_id, text, cx));
-        self.on_input_blur = None;
-        self.on_input_event = None;
         cx.notify();
     }
 }
@@ -161,8 +181,8 @@ impl Focusable for BlockView {
 
 impl Render for BlockView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let content: AnyElement = if let Some(input) = self.input.clone() {
-            input.into_any_element()
+        let content: AnyElement = if let BlockMode::Editing { input, .. } = &self.mode {
+            input.clone().into_any_element()
         } else {
             let text: String = self
                 .page
@@ -217,11 +237,17 @@ impl BlockView {
     }
 
     pub(crate) fn input_focus_handle_for_test(&self, cx: &App) -> Option<FocusHandle> {
-        self.input.as_ref().map(|i| i.focus_handle(cx))
+        match &self.mode {
+            BlockMode::Editing { input, .. } => Some(input.focus_handle(cx)),
+            BlockMode::Viewing => None,
+        }
     }
 
     pub(crate) fn input_entity_for_test(&self) -> Option<Entity<TextInput>> {
-        self.input.clone()
+        match &self.mode {
+            BlockMode::Editing { input, .. } => Some(input.clone()),
+            BlockMode::Viewing => None,
+        }
     }
 }
 
@@ -289,10 +315,8 @@ mod tests {
         cx.update(|window, cx| {
             let input = bv
                 .read(cx)
-                .input
-                .as_ref()
-                .expect("input mounted after focus")
-                .clone();
+                .input_entity_for_test()
+                .expect("input mounted after focus");
             input.update(cx, |i, cx| i.test_replace_all("HI", cx));
             bv.update(cx, |b, cx| b.test_end_editing(window, cx));
         });
@@ -317,8 +341,7 @@ mod tests {
 
         let first_input_id = cx.read(|cx| {
             bv.read(cx)
-                .input
-                .as_ref()
+                .input_entity_for_test()
                 .expect("input mounted")
                 .entity_id()
         });
@@ -332,8 +355,7 @@ mod tests {
         cx.read(|cx| {
             let second_input_id = bv
                 .read(cx)
-                .input
-                .as_ref()
+                .input_entity_for_test()
                 .expect("input still mounted")
                 .entity_id();
             assert_eq!(first_input_id, second_input_id, "no new input created");
@@ -358,10 +380,8 @@ mod tests {
             assert!(bv.read(cx).is_editing(), "click should enter edit mode");
             let input_focus = bv
                 .read(cx)
-                .input
-                .as_ref()
-                .expect("input mounted after click")
-                .focus_handle(cx);
+                .input_focus_handle_for_test(cx)
+                .expect("input mounted after click");
             assert!(
                 input_focus.is_focused(window),
                 "TextInput must hold focus after the click",
@@ -384,6 +404,10 @@ mod tests {
         });
     }
 
+    /// Editing → Viewing via blur. Focuses an unrelated handle so the
+    /// input's `on_blur` listener fires; complements `escape_exits_editing`
+    /// (which exercises the explicit Cancel action path) and the test
+    /// helper `test_end_editing`.
     /// Regression test: pressing Escape while a block is being edited exits
     /// edit mode. Previously the `on_blur` subscription was the only path
     /// out, and its dispatch lagged a draw cycle, so Escape on its own did

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,12 +39,57 @@ const SHORTCUTS: &[(&str, &str)] = &[
     ("?", "Show this help"),
 ];
 
+/// The four mutually-exclusive top-level UI modes. Encoding them as a single
+/// enum keeps overlay invariants (only one open at a time) unrepresentable as
+/// invalid states, and gives transition tests a single field to assert on.
+///
+/// `TagResults` swaps out the page body; `PagePicker` and `ShortcutsHelp` are
+/// absolute-positioned overlays. The enum collapses both into the same axis
+/// so that opening any one always dismisses the others — see plan
+/// `/home/natemcintosh/.claude/plans/there-seem-to-be-abundant-peach.md`.
+pub enum OverlayMode {
+    None,
+    TagResults(SharedString),
+    PagePicker {
+        entity: Entity<PagePicker>,
+        _sub: Subscription,
+    },
+    ShortcutsHelp,
+}
+
+impl OverlayMode {
+    #[must_use]
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    #[must_use]
+    pub fn tag_name(&self) -> Option<&SharedString> {
+        if let Self::TagResults(name) = self {
+            Some(name)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn picker(&self) -> Option<&Entity<PagePicker>> {
+        if let Self::PagePicker { entity, .. } = self {
+            Some(entity)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn is_shortcuts(&self) -> bool {
+        matches!(self, Self::ShortcutsHelp)
+    }
+}
+
 struct RootView {
     focus_handle: FocusHandle,
-    active_tag: Option<SharedString>,
-    picker: Option<Entity<PagePicker>>,
-    picker_sub: Option<Subscription>,
-    shortcuts_visible: bool,
+    overlay: OverlayMode,
     _current_observer: Subscription,
     _tag_observer: Subscription,
 }
@@ -55,13 +100,15 @@ impl RootView {
         let tag_observer = cx.observe_global::<TagIndex>(|_, cx| cx.notify());
         Self {
             focus_handle: cx.focus_handle(),
-            active_tag: None,
-            picker: None,
-            picker_sub: None,
-            shortcuts_visible: false,
+            overlay: OverlayMode::None,
             _current_observer: current_observer,
             _tag_observer: tag_observer,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn overlay(&self) -> &OverlayMode {
+        &self.overlay
     }
 
     /// Focuses the first block of the current page, or the root view if no
@@ -93,7 +140,7 @@ impl RootView {
             eprintln!("open today's journal failed: {err}");
             return;
         }
-        self.active_tag = None;
+        self.overlay = OverlayMode::None;
         self.focus_current(window, cx);
     }
 
@@ -116,33 +163,30 @@ impl RootView {
             eprintln!("open {next:?} failed: {err}");
             return;
         }
-        self.active_tag = None;
+        self.overlay = OverlayMode::None;
         self.focus_current(window, cx);
     }
 
     fn open_tag(&mut self, action: &OpenTag, window: &mut Window, cx: &mut Context<Self>) {
         Self::reindex_current_page(cx);
-        self.active_tag = Some(action.name.clone());
+        self.overlay = OverlayMode::TagResults(action.name.clone());
         // Park focus on RootView so Escape dispatches `CloseTagView` instead of
         // a stale TextInput::Cancel from the previously-edited block.
         window.focus(&self.focus_handle, cx);
         cx.notify();
     }
 
-    /// Escape handler. Dismisses the shortcuts overlay first if visible, then
-    /// falls back to closing the tag-results view. Picker dismissal goes
-    /// through `TextInputEvent::Cancelled` instead — its `TextInput` owns focus.
+    /// Escape handler. Closes whichever overlay is currently active and
+    /// returns to the underlying page. The page picker dismisses itself via
+    /// `TextInputEvent::Cancelled` (its `TextInput` owns focus), so we only
+    /// see `TagResults` / `ShortcutsHelp` here.
     fn close_tag_view(&mut self, _: &CloseTagView, window: &mut Window, cx: &mut Context<Self>) {
-        if self.shortcuts_visible {
-            self.shortcuts_visible = false;
-            window.focus(&self.focus_handle, cx);
-            cx.notify();
+        if matches!(self.overlay, OverlayMode::None) {
             return;
         }
-        if self.active_tag.take().is_some() {
-            self.focus_current(window, cx);
-            cx.notify();
-        }
+        self.overlay = OverlayMode::None;
+        self.focus_current(window, cx);
+        cx.notify();
     }
 
     fn toggle_shortcuts(
@@ -151,13 +195,14 @@ impl RootView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.shortcuts_visible = !self.shortcuts_visible;
-        if self.shortcuts_visible {
+        if matches!(self.overlay, OverlayMode::ShortcutsHelp) {
+            self.overlay = OverlayMode::None;
+            self.focus_current(window, cx);
+        } else {
+            self.overlay = OverlayMode::ShortcutsHelp;
             // Park focus on the root so Escape lands on `CloseTagView` (which
             // also dismisses the overlay) instead of a stale TextInput.
             window.focus(&self.focus_handle, cx);
-        } else {
-            self.focus_current(window, cx);
         }
         cx.notify();
     }
@@ -265,7 +310,7 @@ impl RootView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.picker.is_some() {
+        if matches!(self.overlay, OverlayMode::PagePicker { .. }) {
             return;
         }
         let entries = match Self::collect_picker_entries(cx) {
@@ -288,8 +333,10 @@ impl RootView {
                 }
             },
         );
-        self.picker = Some(picker);
-        self.picker_sub = Some(sub);
+        self.overlay = OverlayMode::PagePicker {
+            entity: picker,
+            _sub: sub,
+        };
         cx.notify();
     }
 
@@ -317,13 +364,11 @@ impl RootView {
         if let Err(err) = result {
             eprintln!("page picker: open failed: {err}");
         }
-        self.active_tag = None;
         self.close_picker(window, cx);
     }
 
     fn close_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.picker = None;
-        self.picker_sub = None;
+        self.overlay = OverlayMode::None;
         self.focus_current(window, cx);
         cx.notify();
     }
@@ -346,7 +391,7 @@ impl RootView {
             eprintln!("open tag result failed: {err}");
             return;
         }
-        self.active_tag = None;
+        self.overlay = OverlayMode::None;
         self.focus_current(window, cx);
         cx.notify();
     }
@@ -426,7 +471,7 @@ impl Render for RootView {
             let p = page.read(cx);
             (p.name().clone(), p.dirty(), p.view().clone())
         };
-        let active_tag = self.active_tag.clone();
+        let active_tag = self.overlay.tag_name().cloned();
         let header_text = if let Some(tag) = active_tag.as_ref() {
             format!("#{}", tag.as_ref())
         } else if dirty {
@@ -443,12 +488,10 @@ impl Render for RootView {
             root.child(view)
         };
 
-        let overlay_child: Option<gpui::AnyElement> = if let Some(picker) = self.picker.clone() {
-            Some(picker.into_any_element())
-        } else if self.shortcuts_visible {
-            Some(Self::render_shortcuts_overlay())
-        } else {
-            None
+        let overlay_child: Option<gpui::AnyElement> = match &self.overlay {
+            OverlayMode::PagePicker { entity, .. } => Some(entity.clone().into_any_element()),
+            OverlayMode::ShortcutsHelp => Some(Self::render_shortcuts_overlay()),
+            OverlayMode::None | OverlayMode::TagResults(_) => None,
         };
 
         if let Some(child) = overlay_child {
@@ -530,6 +573,9 @@ mod tests {
             cx.bind_keys([
                 KeyBinding::new("escape", CloseTagView, Some("RootView")),
                 KeyBinding::new("ctrl-o", OpenPagePicker, Some("RootView")),
+                KeyBinding::new("ctrl-p", NextPage, Some("RootView")),
+                KeyBinding::new("ctrl-.", JumpToToday, Some("RootView")),
+                KeyBinding::new("ctrl-s", SavePage, Some("RootView")),
                 KeyBinding::new("shift-/", ToggleShortcuts, Some("RootView")),
             ]);
             let store = NotesStore::new(&root_dir).unwrap();
@@ -569,7 +615,7 @@ mod tests {
 
         cx.read(|cx| {
             assert_eq!(
-                root.read(cx).active_tag.as_ref().map(AsRef::as_ref),
+                root.read(cx).overlay().tag_name().map(AsRef::as_ref),
                 Some("todo"),
             );
         });
@@ -580,7 +626,7 @@ mod tests {
         cx.read(|cx| {
             let current = cx.global::<CurrentPage>().get().unwrap();
             assert_eq!(current.read(cx).name().as_ref(), "Tagged");
-            assert!(root.read(cx).active_tag.is_none());
+            assert!(root.read(cx).overlay().is_none());
         });
     }
 
@@ -604,14 +650,14 @@ mod tests {
             });
         });
         cx.run_until_parked();
-        assert!(cx.read(|cx| root.read(cx).active_tag.is_some()));
+        assert!(cx.read(|cx| root.read(cx).overlay().tag_name().is_some()));
 
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
 
         cx.read(|cx| {
             assert!(
-                root.read(cx).active_tag.is_none(),
+                root.read(cx).overlay().is_none(),
                 "escape should close the tag-results view",
             );
             let current = cx.global::<CurrentPage>().get().unwrap();
@@ -628,11 +674,11 @@ mod tests {
 
         cx.simulate_keystrokes("shift-/");
         cx.run_until_parked();
-        assert!(cx.read(|cx| root.read(cx).shortcuts_visible));
+        assert!(cx.read(|cx| root.read(cx).overlay().is_shortcuts()));
 
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
-        assert!(!cx.read(|cx| root.read(cx).shortcuts_visible));
+        assert!(cx.read(|cx| root.read(cx).overlay().is_none()));
     }
 
     /// Opening the picker, typing a filter, and pressing Enter switches to the
@@ -647,7 +693,7 @@ mod tests {
 
         cx.read(|cx| {
             assert!(
-                root.read(cx).picker.is_some(),
+                root.read(cx).overlay().picker().is_some(),
                 "picker mounted after ctrl-o",
             );
         });
@@ -660,7 +706,258 @@ mod tests {
         cx.read(|cx| {
             let current = cx.global::<CurrentPage>().get().unwrap();
             assert_eq!(current.read(cx).name().as_ref(), "Tagged");
-            assert!(root.read(cx).picker.is_none(), "picker dismissed on select");
+            assert!(
+                root.read(cx).overlay().is_none(),
+                "picker dismissed on select",
+            );
+        });
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // OverlayMode state-transition tests. One test per discrete transition
+    // listed in the plan; see /home/natemcintosh/.claude/plans/there-
+    // seem-to-be-abundant-peach.md. The shape is always: set the
+    // precondition, fire a simulated input, assert the resulting variant.
+    // ────────────────────────────────────────────────────────────────────
+
+    /// `None` → `PagePicker` via Ctrl-O.
+    #[gpui::test]
+    fn transition_none_to_picker(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+        assert!(cx.read(|cx| root.read(cx).overlay().is_none()));
+
+        cx.simulate_keystrokes("ctrl-o");
+        cx.run_until_parked();
+
+        assert!(cx.read(|cx| root.read(cx).overlay().picker().is_some()));
+    }
+
+    /// `PagePicker` → `None` via Escape (routed through the input's Cancel action).
+    #[gpui::test]
+    fn transition_picker_to_none_via_escape(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+
+        cx.simulate_keystrokes("ctrl-o");
+        cx.run_until_parked();
+        assert!(cx.read(|cx| root.read(cx).overlay().picker().is_some()));
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        assert!(cx.read(|cx| root.read(cx).overlay().is_none()));
+    }
+
+    /// `None` → `ShortcutsHelp` via `?`.
+    #[gpui::test]
+    fn transition_none_to_shortcuts(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+
+        cx.simulate_keystrokes("shift-/");
+        cx.run_until_parked();
+
+        assert!(cx.read(|cx| root.read(cx).overlay().is_shortcuts()));
+    }
+
+    /// `ShortcutsHelp` → `None` via `?` (toggle). Separate from the Escape
+    /// path in `shortcuts_overlay_toggles` — the help cheatsheet calls out
+    /// `?` as the toggle, so the toggle path needs its own regression.
+    #[gpui::test]
+    fn transition_shortcuts_to_none_via_question(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+
+        cx.simulate_keystrokes("shift-/");
+        cx.run_until_parked();
+        assert!(cx.read(|cx| root.read(cx).overlay().is_shortcuts()));
+
+        cx.simulate_keystrokes("shift-/");
+        cx.run_until_parked();
+
+        assert!(cx.read(|cx| root.read(cx).overlay().is_none()));
+    }
+
+    /// `None` → `TagResults` via programmatic `open_tag` dispatch. The
+    /// click-through-tag-chip path is covered by `tags::tests::
+    /// clicking_rendered_tag_dispatches_open_tag`, which feeds `OpenTag`
+    /// here.
+    #[gpui::test]
+    fn transition_none_to_tag_results(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+
+        cx.update(|window, cx| {
+            root.update(cx, |root, cx| {
+                root.open_tag(
+                    &OpenTag {
+                        name: "todo".into(),
+                    },
+                    window,
+                    cx,
+                );
+            });
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            cx.read(|cx| root.read(cx).overlay().tag_name().map(ToString::to_string)),
+            Some("todo".to_string()),
+        );
+    }
+
+    /// Ctrl-P advances the current page and clears any overlay. Starts from
+    /// `TagResults` to also exercise the "any → `None`" branch.
+    #[gpui::test]
+    fn transition_ctrl_p_clears_tag_overlay_and_advances_page(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+
+        cx.update(|window, cx| {
+            root.update(cx, |root, cx| {
+                root.open_tag(
+                    &OpenTag {
+                        name: "todo".into(),
+                    },
+                    window,
+                    cx,
+                );
+            });
+        });
+        cx.run_until_parked();
+        assert!(cx.read(|cx| root.read(cx).overlay().tag_name().is_some()));
+
+        cx.simulate_keystrokes("ctrl-p");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert!(root.read(cx).overlay().is_none(), "tag view cleared");
+            let current = cx.global::<CurrentPage>().get().unwrap();
+            // mount_root started on Home; ctrl-p cycles to the next entry.
+            assert_ne!(current.read(cx).name().as_ref(), "Home");
+        });
+    }
+
+    /// Ctrl-. opens today's journal and clears any overlay.
+    #[gpui::test]
+    fn transition_ctrl_dot_jumps_to_today(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+
+        cx.simulate_keystrokes("shift-/");
+        cx.run_until_parked();
+        assert!(cx.read(|cx| root.read(cx).overlay().is_shortcuts()));
+
+        cx.simulate_keystrokes("ctrl-.");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert!(root.read(cx).overlay().is_none(), "shortcuts cleared");
+            let current = cx.global::<CurrentPage>().get().unwrap();
+            // The journal name is the ISO date, not "Home".
+            assert_ne!(current.read(cx).name().as_ref(), "Home");
+        });
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Cross-cutting invariants. The state-transition tests above each
+    // verify a single edge in isolation; these glue several edges together
+    // to assert properties that span the whole RootView state machine.
+    // ────────────────────────────────────────────────────────────────────
+
+    /// Ctrl-P must auto-save the outgoing page if it is dirty. The unit
+    /// test `registry::tests::set_current_page_autosaves_outgoing` covers
+    /// the registry primitive; this end-to-end variant drives the
+    /// keystroke through the dispatch tree and reads the file back from
+    /// disk to confirm the full save path runs.
+    #[gpui::test]
+    fn invariant_ctrl_p_autosaves_outgoing_dirty_page(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().to_path_buf();
+        let (_root, cx) = mount_root(cx, &tmp);
+
+        cx.update(|_, cx| {
+            let page = cx.global::<CurrentPage>().get().unwrap().clone();
+            let first = page.read(cx).outline().first_block_id().unwrap();
+            page.update(cx, |p, cx| p.set_block_text(first, "ctrlp-edit", cx));
+            assert_eq!(page.read(cx).name().as_ref(), "Home");
+            assert!(page.read(cx).dirty(), "precondition: outgoing dirty");
+        });
+
+        cx.simulate_keystrokes("ctrl-p");
+        cx.run_until_parked();
+
+        let on_disk = std::fs::read_to_string(root_path.join("pages").join("Home.md"))
+            .expect("Home.md written");
+        assert!(
+            on_disk.contains("ctrlp-edit"),
+            "page A should have been flushed; on disk: {on_disk:?}",
+        );
+    }
+
+    /// Page switch clears any active overlay. Verifies the broader
+    /// invariant by stacking it: tag view open → picker open → select
+    /// → overlay is None. The intermediate tag view exit and picker
+    /// dismissal both have to happen for the assertion to hold.
+    #[gpui::test]
+    fn invariant_picker_selection_clears_all_overlays(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (root, cx) = mount_root(cx, &tmp);
+
+        cx.update(|window, cx| {
+            root.update(cx, |root, cx| {
+                root.open_tag(
+                    &OpenTag {
+                        name: "todo".into(),
+                    },
+                    window,
+                    cx,
+                );
+            });
+        });
+        cx.run_until_parked();
+        assert!(cx.read(|cx| root.read(cx).overlay().tag_name().is_some()));
+
+        // Opening the picker over the tag view replaces it — the new
+        // mutually-exclusive enum guarantees only one overlay at once.
+        cx.simulate_keystrokes("ctrl-o");
+        cx.run_until_parked();
+        assert!(cx.read(|cx| root.read(cx).overlay().picker().is_some()));
+
+        cx.simulate_input("Home");
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert!(
+                root.read(cx).overlay().is_none(),
+                "picker selection should leave no overlay active",
+            );
+            let current = cx.global::<CurrentPage>().get().unwrap();
+            assert_eq!(current.read(cx).name().as_ref(), "Home");
+        });
+    }
+
+    /// Ctrl-S persists a dirty page and clears the dirty flag.
+    #[gpui::test]
+    fn transition_ctrl_s_saves_dirty_page(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (_root, cx) = mount_root(cx, &tmp);
+
+        cx.update(|_, cx| {
+            let page = cx.global::<CurrentPage>().get().unwrap().clone();
+            let first = page.read(cx).outline().first_block_id().unwrap();
+            page.update(cx, |p, cx| p.set_block_text(first, "after-edit", cx));
+            assert!(page.read(cx).dirty());
+        });
+
+        cx.simulate_keystrokes("ctrl-s");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let page = cx.global::<CurrentPage>().get().unwrap();
+            assert!(!page.read(cx).dirty(), "ctrl-s clears the dirty flag");
         });
     }
 }

--- a/src/outline_view.rs
+++ b/src/outline_view.rs
@@ -285,6 +285,63 @@ mod tests {
         });
     }
 
+    /// Editing → Viewing via blur. Realized as "focus another block": when
+    /// block 2 takes focus, block 1's input loses focus, its `on_blur`
+    /// listener fires, and block 1 flushes back to view mode.
+    ///
+    /// Done through `OutlineView` rather than `BlockView` directly because
+    /// `BlockView` test setups have no second focusable element to receive
+    /// focus, and `Window::blur` alone does not drive `on_blur` reliably
+    /// in the headless dispatch.
+    #[gpui::test]
+    fn transition_editing_to_viewing_via_blur_across_blocks(cx: &mut TestAppContext) {
+        use crate::block_view::BlockMode;
+        let (page, ov, cx) = mount(cx, "- one\n- two\n");
+
+        let (first_id, second_id) = cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            (outline.roots[0].id, outline.roots[1].id)
+        });
+
+        cx.update(|window, cx| {
+            let bv = ov.update(cx, |o, cx| o.get_or_create(first_id, window, cx));
+            window.focus(&bv.focus_handle(cx), cx);
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            // Force a draw so the input's focus_id is captured in the
+            // rendered_frame focus path. Without this, the next focus
+            // change can't be detected as a blur — the focus listener
+            // compares against the rendered_frame's path.
+            window.draw(cx).clear();
+        });
+        cx.run_until_parked();
+        cx.read(|cx| {
+            let bv = ov.read(cx).block_view(first_id).expect("first mounted");
+            assert!(bv.read(cx).is_editing(), "precondition: first is editing");
+        });
+
+        // Move focus to the second block; this naturally blurs the first
+        // block's TextInput.
+        cx.update(|window, cx| {
+            let other = ov.update(cx, |o, cx| o.get_or_create(second_id, window, cx));
+            window.focus(&other.focus_handle(cx), cx);
+            window.draw(cx).clear();
+        });
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let bv = ov
+                .read(cx)
+                .block_view(first_id)
+                .expect("first still cached");
+            assert!(
+                matches!(bv.read(cx).mode(), BlockMode::Viewing),
+                "blurring the first block should exit its edit mode",
+            );
+        });
+    }
+
     #[test]
     fn flatten_respects_collapsed() {
         let mut a = Block::new("a");

--- a/src/page.rs
+++ b/src/page.rs
@@ -158,4 +158,42 @@ mod tests {
             assert!(p.dirty());
         });
     }
+
+    /// clean → dirty via `insert_block_after`. Companion to the
+    /// `set_block_text` transition test above.
+    #[gpui::test]
+    fn transition_clean_to_dirty_via_insert_block_after(cx: &mut TestAppContext) {
+        let page = cx.new(|cx| Page::new("foo".into(), "- hi\n", cx));
+        let first_id = cx.read(|cx| page.read(cx).outline().roots[0].id);
+        assert!(!cx.read(|cx| page.read(cx).dirty()));
+
+        let new_id = cx
+            .update(|cx| page.update(cx, |p, cx| p.insert_block_after(first_id, "new", cx)))
+            .expect("insert returned id");
+
+        cx.read(|cx| {
+            let p = page.read(cx);
+            assert!(p.dirty(), "insert_block_after marks the page dirty");
+            assert_eq!(p.outline().get(new_id), Some("new"));
+        });
+    }
+
+    /// dirty → clean via `mark_saved`. The registry calls this after a
+    /// successful write; the test exercises the page in isolation.
+    #[gpui::test]
+    fn transition_dirty_to_clean_via_mark_saved(cx: &mut TestAppContext) {
+        let page = cx.new(|cx| Page::new("foo".into(), "- hi\n", cx));
+        let first_id = cx.read(|cx| page.read(cx).outline().roots[0].id);
+
+        cx.update(|cx| {
+            page.update(cx, |p, cx| p.set_block_text(first_id, "edited", cx));
+        });
+        assert!(cx.read(|cx| page.read(cx).dirty()), "precondition: dirty");
+
+        cx.update(|cx| {
+            page.update(cx, Page::mark_saved);
+        });
+
+        assert!(!cx.read(|cx| page.read(cx).dirty()));
+    }
 }

--- a/src/page_picker.rs
+++ b/src/page_picker.rs
@@ -45,6 +45,28 @@ pub enum PagePickerEvent {
     Cancelled,
 }
 
+/// Discrete filter buckets for the picker. The continuous filter string is
+/// collapsed into these three categories so state-transition tests can assert
+/// "this keystroke moved us from X to Y" without depending on the exact
+/// substring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilterCategory {
+    Empty,
+    NonEmptyMatches,
+    NonEmptyNoMatches,
+}
+
+/// Where the selection cursor sits within the filtered list. `NoSelection`
+/// means the filtered list is empty (so there is nothing to highlight); the
+/// three positional variants are used to verify arrow-key wrap-around.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionPosition {
+    NoSelection,
+    First,
+    Middle,
+    Last,
+}
+
 impl EventEmitter<PagePickerEvent> for PagePicker {}
 
 pub struct PagePicker {
@@ -145,6 +167,37 @@ impl PagePicker {
     #[must_use]
     pub fn input(&self) -> Entity<TextInput> {
         self.input.clone()
+    }
+
+    /// Categorize the current filter state for state-machine tests. Reads the
+    /// `TextInput`'s content so it stays consistent with whatever the user has
+    /// typed, including IME composition.
+    #[must_use]
+    pub fn filter_category(&self, cx: &App) -> FilterCategory {
+        let query = self.input.read(cx).content();
+        if query.is_empty() {
+            FilterCategory::Empty
+        } else if self.filtered.is_empty() {
+            FilterCategory::NonEmptyNoMatches
+        } else {
+            FilterCategory::NonEmptyMatches
+        }
+    }
+
+    /// Categorize the highlighted row's position within the filtered list.
+    /// Returns `NoSelection` if the filtered list is empty.
+    #[must_use]
+    pub fn selection_position(&self) -> SelectionPosition {
+        let len = self.filtered.len();
+        if len == 0 {
+            SelectionPosition::NoSelection
+        } else if self.selected == 0 {
+            SelectionPosition::First
+        } else if self.selected == len - 1 {
+            SelectionPosition::Last
+        } else {
+            SelectionPosition::Middle
+        }
     }
 }
 
@@ -327,5 +380,281 @@ mod tests {
     struct SelectionRecorder {
         events: Vec<PagePickerEvent>,
         _sub: Subscription,
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Filter-state transitions. The 3-bucket category enum (Empty,
+    // NonEmptyMatches, NonEmptyNoMatches) collapses every filter string
+    // into one of three states, so the tests below cover every edge in
+    // the state graph.
+    // ────────────────────────────────────────────────────────────────────
+
+    fn mount_picker(cx: &mut TestAppContext) -> (Entity<PagePicker>, &mut gpui::VisualTestContext) {
+        let (picker, vcx) = cx.add_window_view(|window, cx| {
+            text_input::bind_keys(cx);
+            bind_keys(cx);
+            PagePicker::new(entries(), window, cx)
+        });
+        vcx.update(|window, _| window.activate_window());
+        vcx.run_until_parked();
+        (picker, vcx)
+    }
+
+    fn replace_filter(picker: &Entity<PagePicker>, vcx: &mut gpui::VisualTestContext, text: &str) {
+        vcx.update(|_, cx| {
+            picker.update(cx, |p, cx| {
+                p.input.update(cx, |i, cx| i.test_replace_all(text, cx));
+            });
+        });
+        vcx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn filter_transition_empty_to_matches(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        vcx.read(|cx| {
+            assert_eq!(picker.read(cx).filter_category(cx), FilterCategory::Empty);
+        });
+
+        replace_filter(&picker, vcx, "Beta");
+
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).filter_category(cx),
+                FilterCategory::NonEmptyMatches,
+            );
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::First,
+                "selection resets to first on filter change",
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn filter_transition_empty_to_no_matches(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        replace_filter(&picker, vcx, "zzzzz");
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).filter_category(cx),
+                FilterCategory::NonEmptyNoMatches,
+            );
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::NoSelection,
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn filter_transition_matches_to_empty(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        replace_filter(&picker, vcx, "Beta");
+        replace_filter(&picker, vcx, "");
+        vcx.read(|cx| {
+            assert_eq!(picker.read(cx).filter_category(cx), FilterCategory::Empty);
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::First,
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn filter_transition_matches_to_matches(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        replace_filter(&picker, vcx, "a"); // matches Alpha, Beta, Gamma
+        replace_filter(&picker, vcx, "am"); // narrows to Gamma
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).filter_category(cx),
+                FilterCategory::NonEmptyMatches,
+            );
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::First,
+                "narrowed filter resets selection to first",
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn filter_transition_matches_to_no_matches(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        replace_filter(&picker, vcx, "Beta");
+        replace_filter(&picker, vcx, "Betazz");
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).filter_category(cx),
+                FilterCategory::NonEmptyNoMatches,
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn filter_transition_no_matches_to_matches(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        replace_filter(&picker, vcx, "Betazz");
+        replace_filter(&picker, vcx, "Beta");
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).filter_category(cx),
+                FilterCategory::NonEmptyMatches,
+            );
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::First,
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn filter_transition_no_matches_to_empty(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        replace_filter(&picker, vcx, "zzz");
+        replace_filter(&picker, vcx, "");
+        vcx.read(|cx| {
+            assert_eq!(picker.read(cx).filter_category(cx), FilterCategory::Empty);
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::First,
+            );
+        });
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Selection-position transitions. `entries()` has 4 items, so under
+    // the empty filter the list has First (Alpha), two Middles (Beta,
+    // Gamma), Last (journal date). All arrow-key tests below use that
+    // empty-filter list and start from the natural selection position
+    // they want to transition out of.
+    // ────────────────────────────────────────────────────────────────────
+
+    /// Move the selection to position `target` (0-indexed) by dispatching
+    /// the requisite number of `down` keystrokes from the initial First.
+    fn move_selection_to(vcx: &mut gpui::VisualTestContext, steps: usize) {
+        for _ in 0..steps {
+            vcx.simulate_keystrokes("down");
+        }
+        vcx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn selection_first_to_middle_via_down(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        vcx.simulate_keystrokes("down");
+        vcx.run_until_parked();
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::Middle,
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn selection_middle_to_last_via_down(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        // 4 entries → indexes 0,1,2,3. Go 0→1 (Middle), then to 3 (Last)
+        // takes two more downs (1→2→3).
+        move_selection_to(vcx, 3);
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::Last,
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn selection_last_to_first_via_down_wraps(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        // 0→3 = 3 downs to reach Last
+        move_selection_to(vcx, 3);
+        vcx.simulate_keystrokes("down");
+        vcx.run_until_parked();
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::First,
+                "down at Last should wrap to First",
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn selection_first_to_last_via_up_wraps(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        vcx.simulate_keystrokes("up");
+        vcx.run_until_parked();
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::Last,
+                "up at First should wrap to Last",
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn selection_last_to_middle_via_up(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        move_selection_to(vcx, 3);
+        vcx.simulate_keystrokes("up");
+        vcx.run_until_parked();
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::Middle,
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn selection_middle_to_first_via_up(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+        vcx.simulate_keystrokes("down");
+        vcx.run_until_parked();
+        vcx.simulate_keystrokes("up");
+        vcx.run_until_parked();
+        vcx.read(|cx| {
+            assert_eq!(
+                picker.read(cx).selection_position(),
+                SelectionPosition::First,
+            );
+        });
+    }
+
+    /// Escape emits `Cancelled` (complementing `enter_emits_selected`).
+    #[gpui::test]
+    fn escape_emits_cancelled(cx: &mut TestAppContext) {
+        let (picker, vcx) = mount_picker(cx);
+
+        let recorder = vcx.update(|_, cx| {
+            cx.new(|cx| {
+                let sub = cx.subscribe(
+                    &picker,
+                    |this: &mut SelectionRecorder, _, event: &PagePickerEvent, _| {
+                        this.events.push(event.clone());
+                    },
+                );
+                SelectionRecorder {
+                    events: Vec::new(),
+                    _sub: sub,
+                }
+            })
+        });
+
+        vcx.simulate_keystrokes("escape");
+        vcx.run_until_parked();
+
+        recorder.read_with(vcx, |r, _| {
+            assert!(
+                matches!(r.events.as_slice(), [PagePickerEvent::Cancelled]),
+                "got {:?}",
+                r.events,
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Replace `RootView`'s `(active_tag, picker, picker_sub, shortcuts_visible)` tuple with an `OverlayMode` enum — overlays are now mutually exclusive by construction.
- Replace `BlockView`'s three parallel optionals (`input`, `on_input_blur`, `on_input_event`) with a `BlockMode { Viewing | Editing { input, _on_blur, _on_event } }` enum so enter/exit swaps the variant atomically and no dangling subscription can exist.
- Add `FilterCategory` and `SelectionPosition` accessors on `PagePicker` so state-machine tests can assert on discrete buckets instead of strings/indices.
- Add 27 transition tests (147 total, up from 120): one per edge in the state graph plus cross-cutting invariants (Ctrl-P autosaves dirty outgoing, stacked overlays collapse cleanly through picker selection).

## Test plan
- [x] `just check` passes (clippy with `-D warnings -W clippy::pedantic`)
- [x] `cargo nextest run` — 147 tests pass, 0 failures
- [x] Manual smoke: open page, edit block, escape, switch via Ctrl-P, open picker, navigate with arrows, select, open shortcuts, dismiss with ?
- [x] Manual smoke: click a tag chip, escape returns to page; Ctrl-P from tag view clears overlay and advances page

Notable gotcha for future tests: GPUI's `on_blur` listener requires the focused element's id to be in the rendered focus path before blur fires. `run_until_parked()` doesn't trigger draws — `window.draw(cx).clear()` between focus changes does. See `outline_view::tests::transition_editing_to_viewing_via_blur_across_blocks` for the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)