### PR TITLE
fix(focus): keep ctrl-s working after escaping a block edit

### DIFF
--- a/src/block_view.rs
+++ b/src/block_view.rs
@@ -25,6 +25,10 @@ pub enum BlockViewEvent {
     /// after `self.block_id`. The parent should mount/focus the view for the
     /// newly created block.
     FocusRequested(BlockId),
+    /// Editing ended via blur/Escape (not via Enter, which uses
+    /// `FocusRequested`). The parent should park focus on a non-block
+    /// element so window-level key bindings (e.g. ctrl-s) keep dispatching.
+    EditingEnded,
 }
 
 impl EventEmitter<BlockViewEvent> for BlockView {}
@@ -113,6 +117,7 @@ impl BlockView {
         let on_event = cx.subscribe(&input, |this, _input, event, cx| match event {
             TextInputEvent::Cancelled => {
                 this.end_editing_inner(cx);
+                cx.emit(BlockViewEvent::EditingEnded);
             }
             TextInputEvent::Submitted => {
                 this.insert_sibling_below(cx);

--- a/src/main.rs
+++ b/src/main.rs
@@ -960,4 +960,36 @@ mod tests {
             assert!(!page.read(cx).dirty(), "ctrl-s clears the dirty flag");
         });
     }
+
+    /// After escaping out of a block edit, ctrl-s must still dispatch. The
+    /// `TextInput` entity is dropped on Cancel, which previously left focus
+    /// dead — no element matched the `RootView` key context, so the binding
+    /// silently dropped. `OutlineView` now parks focus on itself on
+    /// `BlockViewEvent::EditingEnded` to keep the chain alive.
+    #[gpui::test]
+    fn ctrl_s_works_after_escaping_block_edit(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (_root, cx) = mount_root(cx, &tmp);
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            let page = cx.global::<CurrentPage>().get().unwrap().clone();
+            let first = page.read(cx).outline().first_block_id().unwrap();
+            page.update(cx, |p, cx| p.set_block_text(first, "after-edit", cx));
+            assert!(page.read(cx).dirty());
+        });
+
+        cx.simulate_keystrokes("ctrl-s");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let page = cx.global::<CurrentPage>().get().unwrap();
+            assert!(
+                !page.read(cx).dirty(),
+                "ctrl-s should clear dirty even after escape parked focus",
+            );
+        });
+    }
 }

--- a/src/outline_view.rs
+++ b/src/outline_view.rs
@@ -8,8 +8,8 @@
 use std::collections::{HashMap, HashSet};
 
 use gpui::{
-    div, px, AppContext, Context, Entity, Focusable, IntoElement, ParentElement, Render,
-    SharedString, Styled, Subscription, Window,
+    div, px, AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
+    ParentElement, Render, SharedString, Styled, Subscription, Window,
 };
 
 use crate::block_render::theme;
@@ -19,6 +19,10 @@ use crate::page::Page;
 
 pub struct OutlineView {
     page: Entity<Page>,
+    /// Receives focus when a block exits editing via blur/Escape, so the
+    /// `RootView` key context stays in the focus chain for window-level
+    /// bindings like ctrl-s.
+    focus_handle: FocusHandle,
     blocks: HashMap<BlockId, Entity<BlockView>>,
     /// One subscription per cached `BlockView` listening for
     /// `BlockViewEvent::FocusRequested` so we can mount and focus the target.
@@ -32,6 +36,7 @@ impl OutlineView {
         let sub = cx.observe(&page, |_, _, cx| cx.notify());
         Self {
             page,
+            focus_handle: cx.focus_handle(),
             blocks: HashMap::new(),
             block_subs: HashMap::new(),
             _page_sub: sub,
@@ -66,6 +71,9 @@ impl OutlineView {
                 let target_bv = this.get_or_create(target, window, cx);
                 let handle = target_bv.focus_handle(cx);
                 window.focus(&handle, cx);
+            }
+            BlockViewEvent::EditingEnded => {
+                window.focus(&this.focus_handle, cx);
             }
         });
         self.blocks.insert(id, bv.clone());
@@ -112,7 +120,11 @@ impl Render for OutlineView {
         self.blocks.retain(|id, _| all_ids.contains(id));
         self.block_subs.retain(|id, _| all_ids.contains(id));
 
-        let mut root = div().flex().flex_col().gap_1();
+        let mut root = div()
+            .track_focus(&self.focus_handle)
+            .flex()
+            .flex_col()
+            .gap_1();
         for (depth, id) in flat {
             let bv = self.get_or_create(id, window, cx);
             #[allow(clippy::cast_precision_loss)]


### PR DESCRIPTION
## Summary
- `ctrl-s` is bound with `Some(\"RootView\")` context, so it only dispatches when the focused element's chain contains the `RootView` key context. Escaping out of a block edit dropped the `TextInput` entity and left focus dead — the binding silently failed until the user clicked the blank background.
- `BlockView` now emits `BlockViewEvent::EditingEnded` from the `TextInputEvent::Cancelled` handler (escape path only — not blur, where another element legitimately took focus).
- `OutlineView` grew a `focus_handle`, tracks it on its root div, and parks focus on itself when a child block emits `EditingEnded`. The outline sits inside `RootView`, so its focus chain keeps `RootView` reachable.

## Test plan
- [x] `just check` clean
- [x] `cargo nextest run` — 148/148 pass
- [x] New regression test `ctrl_s_works_after_escaping_block_edit` covers the reported scenario
- [x] Manual: open app, press escape, edit a block, press ctrl-s — save fires without clicking elsewhere first

🤖 Generated with [Claude Code](https://claude.com/claude-code)