### PR TITLE
fix(page): don't mark page dirty when flushed text is unchanged

### DIFF
--- a/src/block_view.rs
+++ b/src/block_view.rs
@@ -436,4 +436,33 @@ mod tests {
 
         cx.read(|cx| assert!(!bv.read(cx).is_editing(), "Escape should exit edit mode"));
     }
+
+    /// Regression test for #39: entering edit mode and leaving it without
+    /// typing flushes identical text back to the page, which must not mark
+    /// the page dirty (and thus must not trigger a file rewrite).
+    #[gpui::test]
+    fn focus_and_blur_without_typing_keeps_page_clean(cx: &mut TestAppContext) {
+        let (page, bv, cx) = mount(cx, "- hi\n");
+
+        cx.update(|window, cx| {
+            let handle = bv.read(cx).focus_handle.clone();
+            window.focus(&handle, cx);
+        });
+        cx.run_until_parked();
+        assert!(
+            cx.read(|cx| bv.read(cx).is_editing()),
+            "precondition: editing",
+        );
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert!(!bv.read(cx).is_editing(), "escape exits edit mode");
+            assert!(
+                !page.read(cx).dirty(),
+                "untouched focus/blur cycle must not dirty the page",
+            );
+        });
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -896,6 +896,46 @@ mod tests {
         );
     }
 
+    /// Regression test for #39: cycling pages with ctrl-p focuses (and thus
+    /// mounts an editor on) the first block of each page and blurs it on the
+    /// next switch. With zero typing, no page may become dirty and no file
+    /// may be rewritten.
+    #[gpui::test]
+    fn invariant_ctrl_p_cycling_keeps_pages_clean(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().to_path_buf();
+        let (_root, cx) = mount_root(cx, &tmp);
+
+        // Home is the outgoing page on the first ctrl-p; its blur-flush is
+        // what used to set the bogus dirty flag.
+        let home = cx.read(|cx| cx.global::<CurrentPage>().get().unwrap().clone());
+        let home_path = root_path.join("pages").join("Home.md");
+        let mtime_before = std::fs::metadata(&home_path).unwrap().modified().unwrap();
+
+        for _ in 0..4 {
+            cx.simulate_keystrokes("ctrl-p");
+            cx.run_until_parked();
+            cx.read(|cx| {
+                assert!(
+                    !home.read(cx).dirty(),
+                    "Home marked dirty by mere page cycling",
+                );
+                let current = cx.global::<CurrentPage>().get().unwrap();
+                assert!(
+                    !current.read(cx).dirty(),
+                    "{:?} marked dirty by mere page cycling",
+                    current.read(cx).name(),
+                );
+            });
+        }
+
+        let mtime_after = std::fs::metadata(&home_path).unwrap().modified().unwrap();
+        assert_eq!(
+            mtime_before, mtime_after,
+            "Home.md rewritten with zero user edits",
+        );
+    }
+
     /// Page switch clears any active overlay. Verifies the broader
     /// invariant by stacking it: tag view open → picker open → select
     /// → overlay is None. The intermediate tag view exit and picker

--- a/src/page.rs
+++ b/src/page.rs
@@ -67,6 +67,12 @@ impl Page {
     }
 
     pub fn set_block_text(&mut self, id: BlockId, text: impl Into<String>, cx: &mut Context<Self>) {
+        let text = text.into();
+        // Flushing identical text (e.g. a focus/blur cycle with no typing)
+        // must not dirty the page or rewrite the file (#39).
+        if self.outline.get(id) == Some(text.as_str()) {
+            return;
+        }
         if !self.outline.set_text(id, text) {
             return;
         }
@@ -156,6 +162,26 @@ mod tests {
             assert_eq!(p.outline().get(first_id), Some("hello"));
             assert_eq!(p.body().as_ref(), "- hello\n");
             assert!(p.dirty());
+        });
+    }
+
+    /// Regression test for #39: flushing text identical to the block's
+    /// current text (e.g. a focus/blur cycle with no typing) must not mark
+    /// the page dirty.
+    #[gpui::test]
+    fn set_block_text_with_unchanged_text_stays_clean(cx: &mut TestAppContext) {
+        let page = cx.new(|cx| Page::new("foo".into(), "- hi\n", cx));
+        let first_id = cx.read(|cx| page.read(cx).outline().roots[0].id);
+
+        cx.update(|cx| {
+            page.update(cx, |p, cx| p.set_block_text(first_id, "hi", cx));
+        });
+
+        cx.read(|cx| {
+            assert!(
+                !page.read(cx).dirty(),
+                "identical text must not dirty the page",
+            );
         });
     }
 


### PR DESCRIPTION
## Summary
`Outline::set_text` returns "block found", not "text changed", so `Page::set_block_text` marked the page dirty on every editor blur — even an untouched focus/blur cycle. Since every page switch focuses the first block (mounting an editor), merely cycling pages with `ctrl-p` left pages perpetually dirty (bogus "•" in the header) and rewrote files on autosave with zero user edits.

The fix is the one comparison suggested in the issue: `Page::set_block_text` returns early (no dirty flag, no notify, no reserialize) when the incoming text equals the block's current text.

## Regression tests
- `page::set_block_text_with_unchanged_text_stays_clean` — identical flush keeps the page clean
- `block_view::focus_and_blur_without_typing_keeps_page_clean` — focus + escape with no typing keeps the page clean
- `main::invariant_ctrl_p_cycling_keeps_pages_clean` — ctrl-p cycling never sets the dirty flag and never rewrites `Home.md` (mtime unchanged)

All three failed before the fix; the full suite (151 tests) passes after, and `just check` is clean.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)