### PR TITLE
fix(block_view): flush in-flight edits to the page on every keystroke

### DIFF
--- a/src/block_view.rs
+++ b/src/block_view.rs
@@ -3,8 +3,9 @@
 //!
 //! Only one block can be in `Editing` at a time — GPUI's focus system enforces
 //! this naturally (a single focused leaf). The outline stored on `Page` is the
-//! source of truth; the `TextInput`'s buffer is flushed to the outline on blur
-//! and then dropped, so there is no hidden state to drift out of sync.
+//! source of truth; the `TextInput`'s buffer is flushed to the outline on every
+//! change (and again on blur, when the input is dropped), so there is no hidden
+//! state to drift out of sync and every save path sees in-flight edits (#38).
 
 use gpui::{
     div, prelude::*, px, AnyElement, App, AppContext, Context, Entity, EventEmitter, FocusHandle,
@@ -122,7 +123,16 @@ impl BlockView {
             TextInputEvent::Submitted => {
                 this.insert_sibling_below(cx);
             }
-            TextInputEvent::Changed(_) => {}
+            // Flush every keystroke to the page so all save paths (ctrl-s,
+            // page-switch autosave, quit-save) see the in-flight text (#38).
+            // `set_block_text` is a no-op on identical text, so this cannot
+            // spuriously dirty the page (#39).
+            TextInputEvent::Changed(text) => {
+                let block_id = this.block_id;
+                let text = text.to_string();
+                this.page
+                    .update(cx, |p, cx| p.set_block_text(block_id, text, cx));
+            }
         });
         window.focus(&input_focus, cx);
         self.mode = BlockMode::Editing {
@@ -435,6 +445,34 @@ mod tests {
         cx.run_until_parked();
 
         cx.read(|cx| assert!(!bv.read(cx).is_editing(), "Escape should exit edit mode"));
+    }
+
+    /// Regression test for #38: typing must flush to the page's outline on
+    /// every `Changed` event, not just on blur/Escape — otherwise ctrl-s and
+    /// page-switch autosave persist stale text while the input is focused.
+    #[gpui::test]
+    fn typing_flushes_to_outline_immediately(cx: &mut TestAppContext) {
+        let (page, bv, cx) = mount(cx, "- hi\n");
+
+        cx.update(|window, cx| {
+            let handle = bv.read(cx).focus_handle.clone();
+            window.focus(&handle, cx);
+        });
+        cx.run_until_parked();
+
+        cx.simulate_input("!!");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert!(bv.read(cx).is_editing(), "still mid-edit — no blur yet");
+            let block_id = bv.read(cx).block_id;
+            assert_eq!(
+                page.read(cx).outline().get(block_id),
+                Some("hi!!"),
+                "outline must reflect the in-flight edit",
+            );
+            assert!(page.read(cx).dirty(), "typing dirties the page");
+        });
     }
 
     /// Regression test for #39: entering edit mode and leaving it without

--- a/src/main.rs
+++ b/src/main.rs
@@ -980,6 +980,62 @@ mod tests {
         );
     }
 
+    /// Regression test for #38: ctrl-s while a block edit is still in
+    /// progress must persist the typed text. Previously the typed text lived
+    /// only in the `TextInput` until blur, so ctrl-s saved the pre-edit body
+    /// (or skipped the write entirely if the page wasn't already dirty).
+    #[gpui::test]
+    fn invariant_ctrl_s_mid_edit_saves_typed_text(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().to_path_buf();
+        let (_root, cx) = mount_root(cx, &tmp);
+
+        // mount_root leaves the first block of Home focused in edit mode,
+        // caret at the end of "home".
+        cx.simulate_input("-typed");
+        cx.run_until_parked();
+        cx.simulate_keystrokes("ctrl-s");
+        cx.run_until_parked();
+
+        let on_disk = std::fs::read_to_string(root_path.join("pages").join("Home.md"))
+            .expect("Home.md written");
+        assert!(
+            on_disk.contains("home-typed"),
+            "ctrl-s mid-edit must save the typed text; on disk: {on_disk:?}",
+        );
+    }
+
+    /// Regression test for #38, page-switch flavor: `set_current_page` saves
+    /// the outgoing page *before* the focus change blurs the input, so the
+    /// in-flight edit must already be in the outline for the autosave to
+    /// persist it.
+    #[gpui::test]
+    fn invariant_ctrl_p_mid_edit_persists_typed_text(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().to_path_buf();
+        let (_root, cx) = mount_root(cx, &tmp);
+
+        let home = cx.read(|cx| cx.global::<CurrentPage>().get().unwrap().clone());
+
+        cx.simulate_input("-typed");
+        cx.run_until_parked();
+        cx.simulate_keystrokes("ctrl-p");
+        cx.run_until_parked();
+
+        let on_disk = std::fs::read_to_string(root_path.join("pages").join("Home.md"))
+            .expect("Home.md written");
+        assert!(
+            on_disk.contains("home-typed"),
+            "outgoing page must be saved with the typed text; on disk: {on_disk:?}",
+        );
+        cx.read(|cx| {
+            assert!(
+                !home.read(cx).dirty(),
+                "outgoing page must be persisted, not left dirty",
+            );
+        });
+    }
+
     /// Page switch clears any active overlay. Verifies the broader
     /// invariant by stacking it: tag view open → picker open → select
     /// → overlay is None. The intermediate tag view exit and picker


### PR DESCRIPTION
Typed text used to live only in the block's `TextInput` until blur/Enter/Escape — `BlockView` ignored `TextInputEvent::Changed`. Save shortcuts still dispatched mid-edit (the binding matches the ancestor `RootView` key context), so:

- **ctrl-s mid-edit saved the pre-edit body** — and if the page wasn't already dirty, `PageRegistry::save` skipped the write entirely.
- **Page-switch autosave had the same ordering hole** — `set_current_page` saved the outgoing page before the focus change blurred the input, leaving the edit unpersisted and the page dirty.

## Fix

Handle `Changed` in the subscription set up by `BlockView::begin_editing` by flushing the live buffer via `Page::set_block_text`. Re-serializing a notes-sized outline per keystroke is cheap, and it makes every save path (ctrl-s, page-switch autosave, quit-save) correct at once. `set_block_text` is a no-op on identical text, so this can't spuriously dirty the page (#39 stays fixed — its regression tests still pass).

## Tests

Both end-to-end regression tests from the issue, verified to fail without the fix:

- `invariant_ctrl_s_mid_edit_saves_typed_text` — type into a block, ctrl-s without leaving edit mode → typed text is on disk
- `invariant_ctrl_p_mid_edit_persists_typed_text` — type into a block, ctrl-p → outgoing page's file contains the typed text and the page is not left dirty

Plus a unit test `typing_flushes_to_outline_immediately` in `block_view.rs`.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)