### PR TITLE
fix(registry): save all dirty pages on app quit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use gpui_notes::cmd_key;
 use gpui_notes::journal;
 use gpui_notes::page::Page;
 use gpui_notes::page_picker::{self, PageEntry, PagePicker, PagePickerEvent};
-use gpui_notes::registry::{pick_next, set_current_page, CurrentPage, PageRegistry};
+use gpui_notes::registry::{
+    pick_next, save_all_on_quit, set_current_page, CurrentPage, PageRegistry,
+};
 use gpui_notes::store::NotesStore;
 use gpui_notes::tags::{self, OpenTag, TagIndex, TagSource};
 use gpui_notes::text_input;
@@ -542,6 +544,7 @@ fn main() {
         cx.set_global(tag_index);
         cx.set_global(PageRegistry::new(store));
         cx.set_global(CurrentPage::default());
+        save_all_on_quit(cx);
         journal::open_today(cx).expect("open today's journal");
 
         let bounds = Bounds::centered(None, size(px(640.0), px(420.0)), cx);
@@ -589,6 +592,7 @@ mod tests {
             cx.set_global(TagIndex::rebuild_from(&store).unwrap());
             cx.set_global(PageRegistry::new(store));
             cx.set_global(CurrentPage::default());
+            save_all_on_quit(cx);
             set_current_page("Home", cx).unwrap();
             RootView::new(cx)
         });
@@ -1034,6 +1038,45 @@ mod tests {
                 "outgoing page must be persisted, not left dirty",
             );
         });
+    }
+
+    /// Regression test for #43: quitting must flush every dirty open page.
+    /// `App::shutdown` is exactly what the platform's quit callback invokes;
+    /// the test platform's `quit()` is a no-op, so the test calls it
+    /// directly. Covers both a mid-edit page (Home, flushed per keystroke
+    /// since #38) and a page dirtied off-screen (Tagged).
+    #[gpui::test]
+    fn invariant_quit_saves_all_dirty_pages(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().to_path_buf();
+        let (_root, cx) = mount_root(cx, &tmp);
+
+        // mount_root leaves the first block of Home focused in edit mode.
+        cx.simulate_input("-typed");
+        cx.run_until_parked();
+        cx.update(|_, cx| {
+            let tagged = cx
+                .update_global::<PageRegistry, _>(|reg, cx| reg.open("Tagged", cx))
+                .unwrap();
+            let first = tagged.read(cx).outline().first_block_id().unwrap();
+            tagged.update(cx, |p, cx| p.set_block_text(first, "tagged-edit", cx));
+            assert!(tagged.read(cx).dirty(), "precondition: Tagged dirty");
+        });
+
+        // Shutdown must run outside a window update — it tears the windows
+        // down — so go through the underlying TestAppContext.
+        cx.cx.update(App::shutdown);
+
+        let home = std::fs::read_to_string(root_path.join("pages/Home.md")).unwrap();
+        let tagged = std::fs::read_to_string(root_path.join("pages/Tagged.md")).unwrap();
+        assert!(
+            home.contains("home-typed"),
+            "quit must save the mid-edit page; on disk: {home:?}",
+        );
+        assert!(
+            tagged.contains("tagged-edit"),
+            "quit must save every dirty page, not just the current one; on disk: {tagged:?}",
+        );
     }
 
     /// Page switch clears any active overlay. Verifies the broader

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -152,6 +152,27 @@ impl PageRegistry {
         Ok(())
     }
 
+    /// Saves every dirty open page. Attempts all pages even if one write
+    /// fails; the first error is returned after the sweep so a single bad
+    /// page cannot block the rest from persisting (#43).
+    ///
+    /// # Errors
+    /// Returns the first I/O error encountered, if any.
+    pub fn save_all(&mut self, cx: &mut App) -> io::Result<()> {
+        let pages: Vec<Entity<Page>> = self
+            .open
+            .values()
+            .map(|entry| entry.entity.clone())
+            .collect();
+        let mut first_err = None;
+        for page in &pages {
+            if let Err(err) = self.save(page, cx) {
+                first_err.get_or_insert(err);
+            }
+        }
+        first_err.map_or(Ok(()), Err)
+    }
+
     #[must_use]
     pub fn source_for_page(&self, page: &Entity<Page>, cx: &App) -> TagSource {
         let name = page.read(cx).name().clone();
@@ -215,6 +236,22 @@ pub fn pick_next<'a>(
         .and_then(|c| names.iter().position(|n| n == c))
         .map_or(0, |i| (i + 1) % names.len());
     Some(&names[idx])
+}
+
+/// Registers an `on_app_quit` observer that saves every dirty open page.
+/// Quit is the one exit path with no other flush (#43): ctrl-s and page
+/// switch cover the rest. On Linux the default `QuitMode` quits when the
+/// last window closes, so this fires for both the window close button and
+/// explicit app quit.
+pub fn save_all_on_quit(cx: &mut App) {
+    cx.on_app_quit(|cx| {
+        let result = cx.update_global::<PageRegistry, io::Result<()>>(PageRegistry::save_all);
+        if let Err(err) = result {
+            eprintln!("quit-save failed: {err}");
+        }
+        async {}
+    })
+    .detach();
 }
 
 /// Saves the outgoing current page if dirty, opens `name` (creating if missing),
@@ -411,6 +448,38 @@ mod tests {
             let page = reg.open_or_create_journal(date, cx).unwrap();
             assert_eq!(page.read(cx).body().as_ref(), "- hello\n");
         });
+    }
+
+    /// Unit test for #43: `save_all` sweeps every open page, persisting the
+    /// dirty ones and leaving clean ones untouched on disk.
+    #[gpui::test]
+    fn save_all_saves_every_dirty_page(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        cx.update(|cx| {
+            let store = NotesStore::new(&root).unwrap();
+            store.write("clean", "- untouched\n").unwrap();
+            let mut reg = PageRegistry::new(store);
+            let a = reg.open_or_create("a", cx).unwrap();
+            let b = reg.open_or_create("b", cx).unwrap();
+            let clean = reg.open("clean", cx).unwrap();
+            a.update(cx, |p, cx| p.set_body_for_test("from-a", cx));
+            b.update(cx, |p, cx| p.set_body_for_test("from-b", cx));
+
+            reg.save_all(cx).unwrap();
+
+            assert!(!a.read(cx).dirty());
+            assert!(!b.read(cx).dirty());
+            assert!(!clean.read(cx).dirty());
+        });
+
+        let a = std::fs::read_to_string(root.join("pages/a.md")).unwrap();
+        let b = std::fs::read_to_string(root.join("pages/b.md")).unwrap();
+        let clean = std::fs::read_to_string(root.join("pages/clean.md")).unwrap();
+        assert_eq!(a, "- from-a\n");
+        assert_eq!(b, "- from-b\n");
+        assert_eq!(clean, "- untouched\n");
     }
 
     #[gpui::test]


### PR DESCRIPTION
Pages were saved on `ctrl-s` and page switch only. Closing the window dropped any dirty page — and any in-flight edit — silently. Quit was the one exit path with no flush.

## Fix

- `PageRegistry::save_all(cx)` sweeps every open page and saves the dirty ones. It attempts all pages even if one write fails, returning the first error after the sweep so a single bad page can't block the rest from persisting.
- `registry::save_all_on_quit(cx)` registers it via `cx.on_app_quit`, called from `main()`. On Linux the default `QuitMode` quits when the last window closes, so the observer fires for both the window close button and explicit app quit (per the issue's "pick whichever fires reliably on both" — on this platform they're the same path).
- With #38 merged, in-flight edits are flushed to the page per keystroke, so quit-save captures a mid-edit block too.

## Tests

- `registry::tests::save_all_saves_every_dirty_page` — unit test: two dirty pages persisted, a clean page left untouched, all flags cleared.
- `invariant_quit_saves_all_dirty_pages` (end-to-end, verified to fail without the hook) — types into Home's focused block mid-edit, dirties Tagged off-screen, then drives the quit path via `App::shutdown` (exactly what the platform's quit callback invokes; the test platform's `quit()` is a no-op) and asserts both files on disk contain the edits.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)