### PR TITLE
fix(registry): key the open-page cache by typed PageKey

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -8,29 +8,36 @@ use crate::page::Page;
 use crate::store::NotesStore;
 use crate::tags::{self, TagSource};
 
-#[derive(Clone, Copy, Debug)]
-enum PageKind {
-    Page,
+/// Cache key for open pages. A regular page literally named `2026-07-13`
+/// and that date's journal are distinct pages living in different
+/// directories; keying the cache by display name let whichever opened
+/// first win and routed the other's saves to the wrong directory (#40).
+/// The typed key makes that collision unrepresentable.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum PageKey {
+    Page(SharedString),
     Journal(NaiveDate),
 }
 
-impl PageKind {
-    fn source(self, key: &SharedString) -> TagSource {
+impl PageKey {
+    fn source(&self) -> TagSource {
         match self {
-            Self::Page => TagSource::Page(key.clone()),
-            Self::Journal(date) => TagSource::Journal(date),
+            Self::Page(name) => TagSource::Page(name.clone()),
+            Self::Journal(date) => TagSource::Journal(*date),
+        }
+    }
+
+    fn display_name(&self) -> SharedString {
+        match self {
+            Self::Page(name) => name.clone(),
+            Self::Journal(date) => date.format("%Y-%m-%d").to_string().into(),
         }
     }
 }
 
-struct OpenPage {
-    entity: Entity<Page>,
-    kind: PageKind,
-}
-
 pub struct PageRegistry {
     store: NotesStore,
-    open: HashMap<SharedString, OpenPage>,
+    open: HashMap<PageKey, Entity<Page>>,
 }
 
 impl Global for PageRegistry {}
@@ -49,12 +56,12 @@ impl PageRegistry {
     /// # Errors
     /// Returns `NotFound` if the page does not exist on disk, or a store I/O error.
     pub fn open(&mut self, name: &str, cx: &mut App) -> io::Result<Entity<Page>> {
-        let key: SharedString = name.to_string().into();
-        if let Some(entry) = self.open.get(&key) {
-            return Ok(entry.entity.clone());
+        let key = PageKey::Page(name.to_string().into());
+        if let Some(entity) = self.open.get(&key) {
+            return Ok(entity.clone());
         }
         let body = self.store.read(name)?;
-        Ok(self.insert(key, &body, PageKind::Page, cx))
+        Ok(self.insert(key, &body, cx))
     }
 
     /// Opens a page, creating it (empty) on disk if it does not yet exist.
@@ -63,9 +70,9 @@ impl PageRegistry {
     /// Returns any I/O error from the underlying store other than `NotFound`
     /// (which triggers creation).
     pub fn open_or_create(&mut self, name: &str, cx: &mut App) -> io::Result<Entity<Page>> {
-        let key: SharedString = name.to_string().into();
-        if let Some(entry) = self.open.get(&key) {
-            return Ok(entry.entity.clone());
+        let key = PageKey::Page(name.to_string().into());
+        if let Some(entity) = self.open.get(&key) {
+            return Ok(entity.clone());
         }
         let body = match self.store.read(name) {
             Ok(body) => body,
@@ -75,7 +82,7 @@ impl PageRegistry {
             }
             Err(err) => return Err(err),
         };
-        Ok(self.insert(key, &body, PageKind::Page, cx))
+        Ok(self.insert(key, &body, cx))
     }
 
     /// Opens the journal for `date`, creating it (empty) on disk if it does not
@@ -90,9 +97,9 @@ impl PageRegistry {
         date: NaiveDate,
         cx: &mut App,
     ) -> io::Result<Entity<Page>> {
-        let key: SharedString = date.format("%Y-%m-%d").to_string().into();
-        if let Some(entry) = self.open.get(&key) {
-            return Ok(entry.entity.clone());
+        let key = PageKey::Journal(date);
+        if let Some(entity) = self.open.get(&key) {
+            return Ok(entity.clone());
         }
         let body = match self.store.read_journal(date) {
             Ok(body) => body,
@@ -102,7 +109,7 @@ impl PageRegistry {
             }
             Err(err) => return Err(err),
         };
-        Ok(self.insert(key, &body, PageKind::Journal(date), cx))
+        Ok(self.insert(key, &body, cx))
     }
 
     /// Lists all page names available on disk.
@@ -138,18 +145,24 @@ impl PageRegistry {
         if !dirty {
             return Ok(());
         }
-        let kind = self
-            .open
-            .get(&name)
-            .map_or(PageKind::Page, |entry| entry.kind);
-        match kind {
-            PageKind::Page => self.store.write(&name, &body)?,
-            PageKind::Journal(date) => self.store.write_journal(date, &body)?,
+        let key = self
+            .key_for(page)
+            .unwrap_or_else(|| PageKey::Page(name.clone()));
+        match &key {
+            PageKey::Page(name) => self.store.write(name, &body)?,
+            PageKey::Journal(date) => self.store.write_journal(*date, &body)?,
         }
         page.update(cx, Page::mark_saved);
-        let source = kind.source(&name);
-        tags::reindex_global_for_page(page, &source, cx);
+        tags::reindex_global_for_page(page, &key.source(), cx);
         Ok(())
+    }
+
+    /// Reverse lookup: the cache key under which `page`'s entity was opened.
+    /// The map is small (open pages only), so a linear scan is fine.
+    fn key_for(&self, page: &Entity<Page>) -> Option<PageKey> {
+        self.open
+            .iter()
+            .find_map(|(key, entity)| (entity.entity_id() == page.entity_id()).then(|| key.clone()))
     }
 
     /// Saves every dirty open page. Attempts all pages even if one write
@@ -159,11 +172,7 @@ impl PageRegistry {
     /// # Errors
     /// Returns the first I/O error encountered, if any.
     pub fn save_all(&mut self, cx: &mut App) -> io::Result<()> {
-        let pages: Vec<Entity<Page>> = self
-            .open
-            .values()
-            .map(|entry| entry.entity.clone())
-            .collect();
+        let pages: Vec<Entity<Page>> = self.open.values().cloned().collect();
         let mut first_err = None;
         for page in &pages {
             if let Err(err) = self.save(page, cx) {
@@ -175,29 +184,16 @@ impl PageRegistry {
 
     #[must_use]
     pub fn source_for_page(&self, page: &Entity<Page>, cx: &App) -> TagSource {
-        let name = page.read(cx).name().clone();
-        self.open.get(&name).map_or_else(
-            || TagSource::Page(name.clone()),
-            |entry| entry.kind.source(&name),
+        self.key_for(page).map_or_else(
+            || TagSource::Page(page.read(cx).name().clone()),
+            |key| key.source(),
         )
     }
 
-    fn insert(
-        &mut self,
-        key: SharedString,
-        body: &str,
-        kind: PageKind,
-        cx: &mut App,
-    ) -> Entity<Page> {
-        let source = kind.source(&key);
-        let page = cx.new(|cx| Page::new(key.clone(), body, cx));
-        self.open.insert(
-            key,
-            OpenPage {
-                entity: page.clone(),
-                kind,
-            },
-        );
+    fn insert(&mut self, key: PageKey, body: &str, cx: &mut App) -> Entity<Page> {
+        let source = key.source();
+        let page = cx.new(|cx| Page::new(key.display_name(), body, cx));
+        self.open.insert(key, page.clone());
         tags::reindex_global_for_page(&page, &source, cx);
         page
     }
@@ -480,6 +476,67 @@ mod tests {
         assert_eq!(a, "- from-a\n");
         assert_eq!(b, "- from-b\n");
         assert_eq!(clean, "- untouched\n");
+    }
+
+    /// Regression test for #40: a regular page literally named like an ISO
+    /// date and that date's journal must be distinct cache entries — each
+    /// opens its own entity and saves to its own directory.
+    #[gpui::test]
+    fn page_named_like_date_does_not_collide_with_journal(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let date = NaiveDate::from_ymd_opt(2026, 1, 2).unwrap();
+
+        cx.update(|cx| {
+            let mut reg = PageRegistry::new(NotesStore::new(&root).unwrap());
+            let page = reg.open_or_create("2026-01-02", cx).unwrap();
+            let journal = reg.open_or_create_journal(date, cx).unwrap();
+            assert_ne!(
+                page.entity_id(),
+                journal.entity_id(),
+                "page and journal with the same display name must be distinct entities",
+            );
+
+            page.update(cx, |p, cx| p.set_body_for_test("page-body", cx));
+            journal.update(cx, |p, cx| p.set_body_for_test("journal-body", cx));
+            reg.save(&page, cx).unwrap();
+            reg.save(&journal, cx).unwrap();
+        });
+
+        let page = std::fs::read_to_string(root.join("pages/2026-01-02.md")).unwrap();
+        let journal = std::fs::read_to_string(root.join("journals/2026-01-02.md")).unwrap();
+        assert_eq!(page, "- page-body\n");
+        assert_eq!(journal, "- journal-body\n");
+    }
+
+    /// The opposite open order of the collision test above: the journal
+    /// opens first, then the page. Both directions used to hit the same
+    /// stale cache entry.
+    #[gpui::test]
+    fn journal_opened_first_does_not_shadow_page(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let date = NaiveDate::from_ymd_opt(2026, 1, 2).unwrap();
+
+        cx.update(|cx| {
+            let mut reg = PageRegistry::new(NotesStore::new(&root).unwrap());
+            let journal = reg.open_or_create_journal(date, cx).unwrap();
+            let page = reg.open_or_create("2026-01-02", cx).unwrap();
+            assert_ne!(page.entity_id(), journal.entity_id());
+
+            page.update(cx, |p, cx| p.set_body_for_test("page-body", cx));
+            reg.save(&page, cx).unwrap();
+        });
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("pages/2026-01-02.md")).unwrap(),
+            "- page-body\n",
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("journals/2026-01-02.md")).unwrap(),
+            "",
+            "journal file must not receive the page's body",
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
`PageRegistry`'s cache was keyed by display name, and a journal's key is its ISO date. A regular page literally named `2026-07-13` and that date's journal therefore shared one cache key: whichever opened first won, the other path got the cached entity, and because the `PageKind` was cached alongside, saves routed to the wrong directory.

## Fix

Per the issue's preferred path (and the repo's "make invalid states unrepresentable" rule), the map is now keyed by

```rust
enum PageKey { Page(SharedString), Journal(NaiveDate) }
```

which makes the collision structurally impossible. `PageKind` falls out of the key entirely. `save` and `source_for_page` resolve a page's key by entity id — a linear scan over the open-page map, which only holds open pages.

## Tests

- `page_named_like_date_does_not_collide_with_journal` — page `"2026-01-02"` and that date's journal open as distinct entities and each saves to its own directory (the issue's regression test).
- `journal_opened_first_does_not_shadow_page` — the opposite open order; asserts the journal file doesn't receive the page's body.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)