### PR TITLE
refactor(focus): decouple focus from edit mode

### DIFF
--- a/src/block_view.rs
+++ b/src/block_view.rs
@@ -1,5 +1,10 @@
-//! Per-block view that swaps between rendered markdown and a raw-text editor
-//! based on focus. See issue #6.
+//! Per-block view that swaps between rendered markdown and a raw-text editor.
+//! See issues #6 and #42.
+//!
+//! Focus and edit mode are decoupled (#42): a focused block merely shows a
+//! focus ring and stays in `Viewing`. Editing starts only on an explicit
+//! trigger — a click on the block body or `enter` on the focused block — and
+//! Escape returns to focused-`Viewing`, parking focus on the block itself.
 //!
 //! Only one block can be in `Editing` at a time — GPUI's focus system enforces
 //! this naturally (a single focused leaf). The outline stored on `Page` is the
@@ -8,9 +13,9 @@
 //! state to drift out of sync and every save path sees in-flight edits (#38).
 
 use gpui::{
-    div, prelude::*, px, AnyElement, App, AppContext, Context, Entity, EventEmitter, FocusHandle,
-    Focusable, IntoElement, MouseButton, ParentElement, Render, SharedString, Styled, Subscription,
-    Window,
+    actions, div, prelude::*, px, AnyElement, App, AppContext, Context, Entity, EventEmitter,
+    FocusHandle, Focusable, IntoElement, KeyBinding, MouseButton, ParentElement, Render,
+    SharedString, Styled, Subscription, Window,
 };
 
 use crate::block_render::{render_block, theme};
@@ -19,17 +24,22 @@ use crate::page::Page;
 use crate::tags::TagExt;
 use crate::text_input::{TextInput, TextInputEvent};
 
+actions!(block_view, [BeginEditing]);
+
+/// Registers the block-level key bindings. The `BlockView` key context only
+/// receives keystrokes while a block wrapper (not its `TextInput`) holds
+/// focus, so `enter` here cannot shadow the input's own enter-to-submit.
+pub fn bind_keys(cx: &mut App) {
+    cx.bind_keys([KeyBinding::new("enter", BeginEditing, Some("BlockView"))]);
+}
+
 /// Events emitted by `BlockView` to its parent (typically `OutlineView`).
 #[derive(Debug, Clone)]
 pub enum BlockViewEvent {
     /// The user finished a block with Enter and a new sibling was inserted
-    /// after `self.block_id`. The parent should mount/focus the view for the
-    /// newly created block.
+    /// after `self.block_id`. The parent should mount the view for the newly
+    /// created block and put it into editing.
     FocusRequested(BlockId),
-    /// Editing ended via blur/Escape (not via Enter, which uses
-    /// `FocusRequested`). The parent should park focus on a non-block
-    /// element so window-level key bindings (e.g. ctrl-s) keep dispatching.
-    EditingEnded,
 }
 
 impl EventEmitter<BlockViewEvent> for BlockView {}
@@ -56,6 +66,8 @@ pub struct BlockView {
     focus_handle: FocusHandle,
     mode: BlockMode,
     _on_focus: Subscription,
+    /// Re-render on wrapper blur so the focus ring clears (#42).
+    _on_self_blur: Subscription,
     _page_sub: Subscription,
 }
 
@@ -67,9 +79,10 @@ impl BlockView {
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
-        let on_focus = cx.on_focus(&focus_handle, window, |this, window, cx| {
-            this.begin_editing(window, cx);
-        });
+        // Focus only draws the ring (#42) — editing is an explicit
+        // transition via click or `enter`, never a focus side effect.
+        let on_focus = cx.on_focus(&focus_handle, window, |_, _, cx| cx.notify());
+        let on_self_blur = cx.on_blur(&focus_handle, window, |_, _, cx| cx.notify());
         // Re-render when the page outline changes (e.g., another block was
         // edited) so our rendered markdown stays current.
         let page_sub = cx.observe(&page, |_, _, cx| cx.notify());
@@ -80,6 +93,7 @@ impl BlockView {
             focus_handle,
             mode: BlockMode::Viewing,
             _on_focus: on_focus,
+            _on_self_blur: on_self_blur,
             _page_sub: page_sub,
         }
     }
@@ -99,7 +113,7 @@ impl BlockView {
         matches!(self.mode, BlockMode::Editing { .. })
     }
 
-    fn begin_editing(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub(crate) fn begin_editing(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if matches!(self.mode, BlockMode::Editing { .. }) {
             return;
         }
@@ -115,23 +129,29 @@ impl BlockView {
         let on_blur = cx.on_blur(&input_focus, window, |this, window, cx| {
             this.end_editing(window, cx);
         });
-        let on_event = cx.subscribe(&input, |this, _input, event, cx| match event {
-            TextInputEvent::Cancelled => {
-                this.end_editing_inner(cx);
-                cx.emit(BlockViewEvent::EditingEnded);
-            }
-            TextInputEvent::Submitted => {
-                this.insert_sibling_below(cx);
-            }
-            // Flush every keystroke to the page so all save paths (ctrl-s,
-            // page-switch autosave, quit-save) see the in-flight text (#38).
-            // `set_block_text` is a no-op on identical text, so this cannot
-            // spuriously dirty the page (#39).
-            TextInputEvent::Changed(text) => {
-                let block_id = this.block_id;
-                let text = text.to_string();
-                this.page
-                    .update(cx, |p, cx| p.set_block_text(block_id, text, cx));
+        let on_event = cx.subscribe_in(&input, window, |this, _input, event, window, cx| {
+            match event {
+                // Escape returns to focused-Viewing on this block (#42), so
+                // the block stays visibly selected and window-level bindings
+                // (ctrl-s etc.) keep dispatching through the focus chain.
+                TextInputEvent::Cancelled => {
+                    this.end_editing_inner(cx);
+                    window.focus(&this.focus_handle, cx);
+                }
+                TextInputEvent::Submitted => {
+                    this.insert_sibling_below(cx);
+                }
+                // Flush every keystroke to the page so all save paths
+                // (ctrl-s, page-switch autosave, quit-save) see the
+                // in-flight text (#38). `set_block_text` is a no-op on
+                // identical text, so this cannot spuriously dirty the
+                // page (#39).
+                TextInputEvent::Changed(text) => {
+                    let block_id = this.block_id;
+                    let text = text.to_string();
+                    this.page
+                        .update(cx, |p, cx| p.set_block_text(block_id, text, cx));
+                }
             }
         });
         window.focus(&input_focus, cx);
@@ -219,6 +239,18 @@ impl Render for BlockView {
             }
         };
 
+        // Focus ring (#42): a focused-but-viewing block is outlined so the
+        // selection is visible without mounting an editor. While editing the
+        // TextInput holds focus, so the ring drops out on its own. The border
+        // is always present (transparent when unfocused) to avoid a 1px
+        // layout shift on focus.
+        let focused = self.focus_handle.is_focused(window) && !self.is_editing();
+        let ring = if focused {
+            theme::accent()
+        } else {
+            gpui::rgba(0x0000_0000)
+        };
+
         // Drive the edit transition directly from the click. `begin_editing`
         // is idempotent — when already editing, the click falls through to
         // the TextInput's own mouse_down (which positions the caret).
@@ -231,9 +263,17 @@ impl Render for BlockView {
         // box turns white but the cursor never appears until a second click.
         div()
             .track_focus(&self.focus_handle)
+            .key_context("BlockView")
+            .on_action(cx.listener(|this, _: &BeginEditing, window, cx| {
+                this.begin_editing(window, cx);
+            }))
             .flex_1()
             .min_h(px(20.0))
             .py_0p5()
+            .px_0p5()
+            .border_1()
+            .border_color(ring)
+            .rounded_sm()
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|this, _, window, cx| {
@@ -292,6 +332,7 @@ mod tests {
         let body = body.to_string();
         let (bv, vcx) = cx.add_window_view(move |window, cx| {
             text_input::bind_keys(cx);
+            super::bind_keys(cx);
             let page = cx.new(|cx| Page::new("foo".into(), &body, cx));
             let block_id = page.read(cx).outline().first_block_id().unwrap();
             cx.set_global(TestPage(page));
@@ -303,28 +344,58 @@ mod tests {
         (page, bv, vcx)
     }
 
-    #[gpui::test]
-    fn focus_enters_editing(cx: &mut TestAppContext) {
-        let (_page, bv, cx) = mount(cx, "- hi\n");
-
-        cx.read(|cx| assert!(!bv.read(cx).is_editing()));
-
+    /// Focuses the block wrapper and settles — the "focused, viewing"
+    /// starting state for the keyboard tests below.
+    fn focus_block(cx: &mut gpui::VisualTestContext, bv: &Entity<BlockView>) {
         cx.update(|window, cx| {
             let handle = bv.read(cx).focus_handle.clone();
             window.focus(&handle, cx);
         });
         cx.run_until_parked();
-        cx.read(|cx| assert!(bv.read(cx).is_editing(), "focus should begin editing"));
+    }
+
+    /// The core of #42: focus alone must not mount an editor. The block is
+    /// focused-but-viewing (the state the focus ring renders in), and only
+    /// an explicit `enter` begins editing.
+    #[gpui::test]
+    fn focus_alone_does_not_enter_editing(cx: &mut TestAppContext) {
+        let (_page, bv, cx) = mount(cx, "- hi\n");
+
+        focus_block(cx, &bv);
+
+        cx.update(|window, cx| {
+            assert!(
+                !bv.read(cx).is_editing(),
+                "focus must highlight, not edit (#42)",
+            );
+            assert!(
+                bv.read(cx).focus_handle.is_focused(window),
+                "wrapper keeps focus in the viewing state",
+            );
+        });
+
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+
+        cx.update(|window, cx| {
+            assert!(bv.read(cx).is_editing(), "enter begins editing");
+            let input_focus = bv
+                .read(cx)
+                .input_focus_handle_for_test(cx)
+                .expect("input mounted after enter");
+            assert!(
+                input_focus.is_focused(window),
+                "TextInput takes focus once editing starts",
+            );
+        });
     }
 
     #[gpui::test]
     fn end_editing_flushes_to_outline(cx: &mut TestAppContext) {
         let (page, bv, cx) = mount(cx, "- hi\n");
 
-        cx.update(|window, cx| {
-            let handle = bv.read(cx).focus_handle.clone();
-            window.focus(&handle, cx);
-        });
+        focus_block(cx, &bv);
+        cx.simulate_keystrokes("enter");
         cx.run_until_parked();
 
         cx.update(|window, cx| {
@@ -344,14 +415,13 @@ mod tests {
         });
     }
 
+    /// `begin_editing` is idempotent: clicking a block that is already being
+    /// edited must not remount the `TextInput` (that would drop the caret).
     #[gpui::test]
-    fn refocusing_same_block_is_noop(cx: &mut TestAppContext) {
+    fn clicking_editing_block_keeps_same_input(cx: &mut TestAppContext) {
         let (_page, bv, cx) = mount(cx, "- hi\n");
 
-        cx.update(|window, cx| {
-            let handle = bv.read(cx).focus_handle.clone();
-            window.focus(&handle, cx);
-        });
+        cx.simulate_click(point(px(20.0), px(20.0)), Modifiers::default());
         cx.run_until_parked();
 
         let first_input_id = cx.read(|cx| {
@@ -361,10 +431,7 @@ mod tests {
                 .entity_id()
         });
 
-        cx.update(|window, cx| {
-            let handle = bv.read(cx).focus_handle.clone();
-            window.focus(&handle, cx);
-        });
+        cx.simulate_click(point(px(20.0), px(20.0)), Modifiers::default());
         cx.run_until_parked();
 
         cx.read(|cx| {
@@ -419,22 +486,16 @@ mod tests {
         });
     }
 
-    /// Editing → Viewing via blur. Focuses an unrelated handle so the
-    /// input's `on_blur` listener fires; complements `escape_exits_editing`
-    /// (which exercises the explicit Cancel action path) and the test
-    /// helper `test_end_editing`.
-    /// Regression test: pressing Escape while a block is being edited exits
-    /// edit mode. Previously the `on_blur` subscription was the only path
-    /// out, and its dispatch lagged a draw cycle, so Escape on its own did
-    /// nothing.
+    /// Escape exits editing back to focused-Viewing (#42): the input is
+    /// dropped and focus parks on the block's own wrapper handle, so the
+    /// block stays visibly selected and window-level bindings keep
+    /// dispatching. Enter must then be able to re-enter editing.
     #[gpui::test]
-    fn escape_exits_editing(cx: &mut TestAppContext) {
+    fn escape_returns_to_focused_viewing(cx: &mut TestAppContext) {
         let (_page, bv, cx) = mount(cx, "- hi\n");
 
-        cx.update(|window, cx| {
-            let handle = bv.read(cx).focus_handle.clone();
-            window.focus(&handle, cx);
-        });
+        focus_block(cx, &bv);
+        cx.simulate_keystrokes("enter");
         cx.run_until_parked();
         assert!(
             cx.read(|cx| bv.read(cx).is_editing()),
@@ -444,7 +505,22 @@ mod tests {
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
 
-        cx.read(|cx| assert!(!bv.read(cx).is_editing(), "Escape should exit edit mode"));
+        cx.update(|window, cx| {
+            assert!(!bv.read(cx).is_editing(), "Escape should exit edit mode");
+            assert!(
+                bv.read(cx).focus_handle.is_focused(window),
+                "Escape must park focus back on the block wrapper",
+            );
+        });
+
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        cx.read(|cx| {
+            assert!(
+                bv.read(cx).is_editing(),
+                "enter re-enters editing from focused-Viewing",
+            );
+        });
     }
 
     /// Regression test for #38: typing must flush to the page's outline on
@@ -454,10 +530,8 @@ mod tests {
     fn typing_flushes_to_outline_immediately(cx: &mut TestAppContext) {
         let (page, bv, cx) = mount(cx, "- hi\n");
 
-        cx.update(|window, cx| {
-            let handle = bv.read(cx).focus_handle.clone();
-            window.focus(&handle, cx);
-        });
+        focus_block(cx, &bv);
+        cx.simulate_keystrokes("enter");
         cx.run_until_parked();
 
         cx.simulate_input("!!");
@@ -479,13 +553,11 @@ mod tests {
     /// typing flushes identical text back to the page, which must not mark
     /// the page dirty (and thus must not trigger a file rewrite).
     #[gpui::test]
-    fn focus_and_blur_without_typing_keeps_page_clean(cx: &mut TestAppContext) {
+    fn edit_and_escape_without_typing_keeps_page_clean(cx: &mut TestAppContext) {
         let (page, bv, cx) = mount(cx, "- hi\n");
 
-        cx.update(|window, cx| {
-            let handle = bv.read(cx).focus_handle.clone();
-            window.focus(&handle, cx);
-        });
+        focus_block(cx, &bv);
+        cx.simulate_keystrokes("enter");
         cx.run_until_parked();
         assert!(
             cx.read(|cx| bv.read(cx).is_editing()),
@@ -499,7 +571,7 @@ mod tests {
             assert!(!bv.read(cx).is_editing(), "escape exits edit mode");
             assert!(
                 !page.read(cx).dirty(),
-                "untouched focus/blur cycle must not dirty the page",
+                "untouched edit/escape cycle must not dirty the page",
             );
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use gpui::{
     FocusHandle, Focusable, IntoElement, KeyBinding, MouseButton, ParentElement, Render,
     SharedString, Styled, Subscription, Window, WindowBounds, WindowOptions,
 };
+use gpui_notes::block_view;
 use gpui_notes::cmd_key;
 use gpui_notes::journal;
 use gpui_notes::page::Page;
@@ -523,6 +524,7 @@ impl Render for RootView {
 fn main() {
     application().run(|cx: &mut App| {
         text_input::bind_keys(cx);
+        block_view::bind_keys(cx);
         page_picker::bind_keys(cx);
         let cmd = cmd_key();
         cx.bind_keys([
@@ -577,6 +579,7 @@ mod tests {
         let root_dir = tmp.path().to_path_buf();
         let (root, vcx) = cx.add_window_view(move |_window, cx| {
             text_input::bind_keys(cx);
+            block_view::bind_keys(cx);
             page_picker::bind_keys(cx);
             cx.bind_keys([
                 KeyBinding::new("escape", CloseTagView, Some("RootView")),
@@ -700,7 +703,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let (root, cx) = mount_root(cx, &tmp);
 
-        // mount_root leaves the first block of Home focused in edit mode.
+        // mount_root leaves the first block of Home focused-but-viewing
+        // (#42); enter begins the edit.
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
         cx.simulate_keystrokes("shift-/");
         cx.run_until_parked();
 
@@ -994,8 +1000,10 @@ mod tests {
         let root_path = tmp.path().to_path_buf();
         let (_root, cx) = mount_root(cx, &tmp);
 
-        // mount_root leaves the first block of Home focused in edit mode,
+        // Enter begins editing the focused first block of Home (#42),
         // caret at the end of "home".
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
         cx.simulate_input("-typed");
         cx.run_until_parked();
         cx.simulate_keystrokes("ctrl-s");
@@ -1021,6 +1029,8 @@ mod tests {
 
         let home = cx.read(|cx| cx.global::<CurrentPage>().get().unwrap().clone());
 
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
         cx.simulate_input("-typed");
         cx.run_until_parked();
         cx.simulate_keystrokes("ctrl-p");
@@ -1040,6 +1050,51 @@ mod tests {
         });
     }
 
+    /// End-to-end #42: after mount and after every page switch the first
+    /// block is focused but NOT editing. Stray typing must change nothing;
+    /// only an explicit `enter` begins an edit. (Asserted through behavior
+    /// because the bin test crate can't reach the lib's cfg(test) helpers.)
+    #[gpui::test]
+    fn page_switch_lands_focused_not_editing(cx: &mut TestAppContext) {
+        let tmp = tempfile::tempdir().unwrap();
+        let (_root, cx) = mount_root(cx, &tmp);
+
+        let home = cx.read(|cx| cx.global::<CurrentPage>().get().unwrap().clone());
+        cx.simulate_input("zzz");
+        cx.run_until_parked();
+        cx.read(|cx| {
+            assert!(
+                !home.read(cx).body().contains("zzz"),
+                "typing after mount must not land anywhere — no editor is open",
+            );
+            assert!(!home.read(cx).dirty(), "page untouched by stray typing");
+        });
+
+        cx.simulate_keystrokes("ctrl-p");
+        cx.run_until_parked();
+        let incoming = cx.read(|cx| cx.global::<CurrentPage>().get().unwrap().clone());
+        cx.simulate_input("zzz");
+        cx.run_until_parked();
+        cx.read(|cx| {
+            assert!(
+                !incoming.read(cx).body().contains("zzz"),
+                "page switch must land focused-but-viewing (#42)",
+            );
+            assert!(!incoming.read(cx).dirty());
+        });
+
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        cx.simulate_input("zzz");
+        cx.run_until_parked();
+        cx.read(|cx| {
+            assert!(
+                incoming.read(cx).body().contains("zzz"),
+                "explicit enter begins editing and typing lands",
+            );
+        });
+    }
+
     /// Regression test for #43: quitting must flush every dirty open page.
     /// `App::shutdown` is exactly what the platform's quit callback invokes;
     /// the test platform's `quit()` is a no-op, so the test calls it
@@ -1051,7 +1106,9 @@ mod tests {
         let root_path = tmp.path().to_path_buf();
         let (_root, cx) = mount_root(cx, &tmp);
 
-        // mount_root leaves the first block of Home focused in edit mode.
+        // Enter begins editing the focused first block of Home (#42).
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
         cx.simulate_input("-typed");
         cx.run_until_parked();
         cx.update(|_, cx| {
@@ -1147,8 +1204,8 @@ mod tests {
     /// After escaping out of a block edit, ctrl-s must still dispatch. The
     /// `TextInput` entity is dropped on Cancel, which previously left focus
     /// dead — no element matched the `RootView` key context, so the binding
-    /// silently dropped. `OutlineView` now parks focus on itself on
-    /// `BlockViewEvent::EditingEnded` to keep the chain alive.
+    /// silently dropped. Escape now parks focus on the block's own wrapper
+    /// (#42), which sits under `RootView`, keeping the chain alive.
     #[gpui::test]
     fn ctrl_s_works_after_escaping_block_edit(cx: &mut TestAppContext) {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/outline_view.rs
+++ b/src/outline_view.rs
@@ -19,9 +19,8 @@ use crate::page::Page;
 
 pub struct OutlineView {
     page: Entity<Page>,
-    /// Receives focus when a block exits editing via blur/Escape, so the
-    /// `RootView` key context stays in the focus chain for window-level
-    /// bindings like ctrl-s.
+    /// Fallback focus target (e.g. an empty outline); a block exiting edit
+    /// mode parks focus on the block itself (#42), not here.
     focus_handle: FocusHandle,
     blocks: HashMap<BlockId, Entity<BlockView>>,
     /// One subscription per cached `BlockView` listening for
@@ -69,11 +68,10 @@ impl OutlineView {
             BlockViewEvent::FocusRequested(target) => {
                 let target = *target;
                 let target_bv = this.get_or_create(target, window, cx);
-                let handle = target_bv.focus_handle(cx);
-                window.focus(&handle, cx);
-            }
-            BlockViewEvent::EditingEnded => {
-                window.focus(&this.focus_handle, cx);
+                // Focus no longer implies editing (#42), so the new sibling
+                // must be put into editing explicitly — the user pressed
+                // Enter to keep typing. `begin_editing` focuses the input.
+                target_bv.update(cx, |bv, cx| bv.begin_editing(window, cx));
             }
         });
         self.blocks.insert(id, bv.clone());
@@ -168,6 +166,7 @@ mod tests {
         let body = body.to_string();
         let (ov, vcx) = cx.add_window_view(move |_window, cx| {
             text_input::bind_keys(cx);
+            crate::block_view::bind_keys(cx);
             let page = cx.new(|cx| Page::new("foo".into(), &body, cx));
             cx.set_global(TestPage(page));
             OutlineView::new(cx.global::<TestPage>().0.clone(), cx)
@@ -194,7 +193,9 @@ mod tests {
         });
         cx.run_until_parked();
 
-        cx.simulate_keystrokes("enter");
+        // First enter begins editing the focused block (#42); the second,
+        // now dispatched to the TextInput, submits and creates the sibling.
+        cx.simulate_keystrokes("enter enter");
         cx.run_until_parked();
 
         // Outline now has 3 roots in order: a, <new>, b.
@@ -246,7 +247,7 @@ mod tests {
         });
         cx.run_until_parked();
 
-        cx.simulate_keystrokes("enter");
+        cx.simulate_keystrokes("enter enter");
         cx.run_until_parked();
 
         // Write into the new block's TextInput directly, then drive the blur
@@ -284,7 +285,7 @@ mod tests {
         });
         cx.run_until_parked();
 
-        cx.simulate_keystrokes("enter");
+        cx.simulate_keystrokes("enter enter");
         cx.run_until_parked();
 
         cx.read(|cx| {
@@ -320,6 +321,9 @@ mod tests {
             window.focus(&bv.focus_handle(cx), cx);
         });
         cx.run_until_parked();
+        // Focus no longer implies editing (#42) — enter starts the edit.
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
         cx.update(|window, cx| {
             // Force a draw so the input's focus_id is captured in the
             // rendered_frame focus path. Without this, the next focus
@@ -350,6 +354,36 @@ mod tests {
             assert!(
                 matches!(bv.read(cx).mode(), BlockMode::Viewing),
                 "blurring the first block should exit its edit mode",
+            );
+        });
+    }
+
+    /// The page-switch mechanism for #42: `RootView::focus_current` lands on
+    /// `focus_first_block`, which must leave the block focused-but-viewing —
+    /// no `TextInput` mounts and the page cannot be touched by the switch.
+    #[gpui::test]
+    fn focus_first_block_does_not_mount_editor(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n- b\n");
+
+        cx.update(|window, cx| {
+            ov.update(cx, |o, cx| o.focus_first_block(window, cx));
+        });
+        cx.run_until_parked();
+
+        cx.update(|window, cx| {
+            let first_id = page.read(cx).outline().roots[0].id;
+            let bv = ov
+                .read(cx)
+                .block_view(first_id)
+                .expect("first block view cached")
+                .clone();
+            assert!(
+                !bv.read(cx).is_editing(),
+                "focus_first_block must not mount an editor (#42)",
+            );
+            assert!(
+                bv.read(cx).focus_handle(cx).is_focused(window),
+                "first block holds focus in viewing mode",
             );
         });
     }


### PR DESCRIPTION
Focus *was* the mode system: `BlockView` entered edit mode as a side effect of receiving focus and exited as a side effect of losing it. Every page switch silently dropped the first block into edit mode, transitions materialized on the next redraw, and there was nowhere to hang keyboard navigation (#44).

## What changed

- **Focused-but-viewing is a real state.** The wrapper handle gaining focus only draws a focus ring (an always-present border that swaps transparent→accent, so no layout shift). No editor mounts.
- **Editing is an explicit transition**: click on the block body (today's path, unchanged) or `enter` on the focused block. The `enter` binding lives on a new `BlockView` key context; the `TextInput` context is deeper in the dispatch path, so enter-to-submit and escape-to-cancel inside the editor are unaffected.
- **Escape returns to focused-Viewing**, parking focus on the block itself — it stays visibly selected and `RootView` bindings (ctrl-s etc.) keep dispatching. `BlockViewEvent::EditingEnded` and `OutlineView`'s focus parking are gone; blur still ends an edit (with #38, text is already flushed per keystroke, so nothing is lost either way).
- **Enter-created siblings** are put into editing explicitly by `OutlineView`'s `FocusRequested` handler, since focus no longer implies editing.
- Page switches / overlay closes land on "first block focused, viewing" — calm, no editor, no dirty risk.

## Tests (all via simulation APIs)

- `focus_alone_does_not_enter_editing` — focus highlights; `enter` begins editing with the input focused
- `escape_returns_to_focused_viewing` — escape exits editing, focus parks on the block, `enter` re-enters
- `focus_first_block_does_not_mount_editor` — the page-switch mechanism mounts no editor
- `page_switch_lands_focused_not_editing` (end-to-end) — stray typing after mount/switch changes nothing; typing after `enter` lands
- Existing suites updated for the explicit-enter model (siblings now take `enter enter`: begin edit, then submit); `ctrl_s_works_after_escaping_block_edit`, the #38/#39 regression tests, and the tag/overlay suites all still pass — 160/160.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)