### PR TITLE
feat(outline): keyboard navigation and block operations

### DIFF
--- a/src/block_view.rs
+++ b/src/block_view.rs
@@ -30,7 +30,11 @@ actions!(block_view, [BeginEditing]);
 /// receives keystrokes while a block wrapper (not its `TextInput`) holds
 /// focus, so `enter` here cannot shadow the input's own enter-to-submit.
 pub fn bind_keys(cx: &mut App) {
-    cx.bind_keys([KeyBinding::new("enter", BeginEditing, Some("BlockView"))]);
+    cx.bind_keys([KeyBinding::new(
+        "enter",
+        BeginEditing,
+        Some("BlockView && !editing"),
+    )]);
 }
 
 /// Events emitted by `BlockView` to its parent (typically `OutlineView`).
@@ -261,9 +265,19 @@ impl Render for BlockView {
         // listener fires *after* `begin_editing` and re-focuses the wrapper's
         // own handle, stealing focus from the freshly mounted TextInput — the
         // box turns white but the cursor never appears until a second click.
+        // The `editing` flag lets outline-op bindings scope themselves to
+        // "BlockView && !editing" (#44): the wrapper is an ancestor of the
+        // TextInput, so without the flag, keys the input doesn't bind
+        // (up/down/tab…) would trigger outline ops mid-edit.
+        let key_context = if self.is_editing() {
+            "BlockView editing"
+        } else {
+            "BlockView"
+        };
+
         div()
             .track_focus(&self.focus_handle)
-            .key_context("BlockView")
+            .key_context(key_context)
             .on_action(cx.listener(|this, _: &BeginEditing, window, cx| {
                 this.begin_editing(window, cx);
             }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use gpui::{
 use gpui_notes::block_view;
 use gpui_notes::cmd_key;
 use gpui_notes::journal;
+use gpui_notes::outline_view;
 use gpui_notes::page::Page;
 use gpui_notes::page_picker::{self, PageEntry, PagePicker, PagePickerEvent};
 use gpui_notes::registry::{
@@ -33,17 +34,24 @@ actions!(
 
 /// Cheatsheet shown in the shortcuts overlay. The strings here are the only
 /// place the bindings are documented to the user — keep in sync with the
-/// `cx.bind_keys(...)` block in `main`. Labels derive from the same platform
+/// `cx.bind_keys(...)` block in `main` and the `bind_keys` fns of
+/// `block_view`/`outline_view`. Labels derive from the same platform
 /// modifier as the bindings, so macOS shows `cmd-*`.
-fn shortcuts() -> [(String, &'static str); 6] {
+fn shortcuts() -> Vec<(String, &'static str)> {
     let cmd = cmd_key();
-    [
+    vec![
         (format!("{cmd}-o"), "Open page…"),
         (format!("{cmd}-p"), "Cycle to next page"),
         (format!("{cmd}-."), "Jump to today's journal"),
         (format!("{cmd}-s"), "Save current page"),
-        ("escape".to_string(), "Close overlay / tag view"),
+        ("escape".to_string(), "Close overlay / stop editing"),
         (format!("{cmd}-/"), "Show this help"),
+        ("enter".to_string(), "Edit focused block"),
+        ("up / down".to_string(), "Move focus between blocks"),
+        ("tab / shift-tab".to_string(), "Indent / outdent block"),
+        ("alt-up / alt-down".to_string(), "Move block up / down"),
+        (format!("{cmd}-enter"), "Collapse / expand block"),
+        ("backspace".to_string(), "Delete empty block"),
     ]
 }
 
@@ -525,6 +533,7 @@ fn main() {
     application().run(|cx: &mut App| {
         text_input::bind_keys(cx);
         block_view::bind_keys(cx);
+        outline_view::bind_keys(cx);
         page_picker::bind_keys(cx);
         let cmd = cmd_key();
         cx.bind_keys([
@@ -580,6 +589,7 @@ mod tests {
         let (root, vcx) = cx.add_window_view(move |_window, cx| {
             text_input::bind_keys(cx);
             block_view::bind_keys(cx);
+            outline_view::bind_keys(cx);
             page_picker::bind_keys(cx);
             cx.bind_keys([
                 KeyBinding::new("escape", CloseTagView, Some("RootView")),

--- a/src/outline_view.rs
+++ b/src/outline_view.rs
@@ -8,14 +8,49 @@
 use std::collections::{HashMap, HashSet};
 
 use gpui::{
-    div, px, AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
-    ParentElement, Render, SharedString, Styled, Subscription, Window,
+    actions, div, px, App, AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement,
+    IntoElement, KeyBinding, ParentElement, Render, SharedString, Styled, Subscription, Window,
 };
 
 use crate::block_render::theme;
 use crate::block_view::{BlockView, BlockViewEvent};
 use crate::outline::{Block, BlockId};
 use crate::page::Page;
+
+actions!(
+    outline_view,
+    [
+        FocusUp,
+        FocusDown,
+        IndentBlock,
+        OutdentBlock,
+        MoveBlockUp,
+        MoveBlockDown,
+        ToggleCollapse,
+        DeleteBackward
+    ]
+);
+
+/// The outline navigation/operation keys act on the focused-but-viewing
+/// block (#42/#44). The `!editing` guard keeps them from firing while that
+/// block's `TextInput` is focused — the wrapper (and its key context) is an
+/// ancestor of the input, so without the guard, keys the input doesn't bind
+/// (up/down/tab…) would leak into outline ops mid-edit.
+const BLOCK_CONTEXT: &str = "BlockView && !editing";
+
+pub fn bind_keys(cx: &mut App) {
+    let cmd = crate::cmd_key();
+    cx.bind_keys([
+        KeyBinding::new("up", FocusUp, Some(BLOCK_CONTEXT)),
+        KeyBinding::new("down", FocusDown, Some(BLOCK_CONTEXT)),
+        KeyBinding::new("tab", IndentBlock, Some(BLOCK_CONTEXT)),
+        KeyBinding::new("shift-tab", OutdentBlock, Some(BLOCK_CONTEXT)),
+        KeyBinding::new("alt-up", MoveBlockUp, Some(BLOCK_CONTEXT)),
+        KeyBinding::new("alt-down", MoveBlockDown, Some(BLOCK_CONTEXT)),
+        KeyBinding::new(&format!("{cmd}-enter"), ToggleCollapse, Some(BLOCK_CONTEXT)),
+        KeyBinding::new("backspace", DeleteBackward, Some(BLOCK_CONTEXT)),
+    ]);
+}
 
 pub struct OutlineView {
     page: Entity<Page>,
@@ -79,11 +114,101 @@ impl OutlineView {
         bv
     }
 
+    /// The id of the block whose wrapper currently holds focus (i.e. the
+    /// focused-but-viewing block the outline keys operate on).
+    fn focused_block_id(&self, window: &Window, cx: &App) -> Option<BlockId> {
+        self.blocks.iter().find_map(|(id, bv)| {
+            bv.read(cx)
+                .focus_handle(cx)
+                .is_focused(window)
+                .then_some(*id)
+        })
+    }
+
+    /// Move focus `delta` steps through the visible (collapse-respecting)
+    /// flattened order. Clamps at both ends.
+    fn move_focus(&mut self, delta: isize, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(current) = self.focused_block_id(window, cx) else {
+            return;
+        };
+        let flat = flatten_visible(&self.page.read(cx).outline().roots);
+        let Some(idx) = flat.iter().position(|&(_, id)| id == current) else {
+            return;
+        };
+        let Some(new_idx) = idx.checked_add_signed(delta).filter(|i| *i < flat.len()) else {
+            return;
+        };
+        let (_, target) = flat[new_idx];
+        let bv = self.get_or_create(target, window, cx);
+        let handle = bv.focus_handle(cx);
+        window.focus(&handle, cx);
+    }
+
+    /// Run one of the `Page` outline ops on the focused block. Focus stays
+    /// on the same block — its `BlockView` survives the re-render because
+    /// the ops never change block ids.
+    fn update_focused_block(
+        &mut self,
+        window: &Window,
+        cx: &mut Context<Self>,
+        op: impl FnOnce(&mut Page, BlockId, &mut Context<Page>) -> bool,
+    ) {
+        let Some(current) = self.focused_block_id(window, cx) else {
+            return;
+        };
+        self.page.update(cx, |page, cx| {
+            op(page, current, cx);
+        });
+    }
+
+    /// Backspace on an empty, childless focused block deletes it and moves
+    /// focus to the previous visible block (or the next one when the first
+    /// block is deleted). Non-empty blocks, blocks with children, and the
+    /// only remaining block are left alone.
+    fn delete_backward(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(current) = self.focused_block_id(window, cx) else {
+            return;
+        };
+        let (flat, deletable) = {
+            let outline = self.page.read(cx).outline();
+            let deletable = outline.get(current) == Some("")
+                && outline
+                    .path_to(current)
+                    .is_some_and(|path| children_at(&outline.roots, &path).is_empty());
+            (flatten_visible(&outline.roots), deletable)
+        };
+        if !deletable || flat.len() <= 1 {
+            return;
+        }
+        let Some(idx) = flat.iter().position(|&(_, id)| id == current) else {
+            return;
+        };
+        let neighbor = if idx > 0 { flat[idx - 1].1 } else { flat[1].1 };
+        self.page.update(cx, |page, cx| {
+            page.delete_block(current, cx);
+        });
+        let bv = self.get_or_create(neighbor, window, cx);
+        let handle = bv.focus_handle(cx);
+        window.focus(&handle, cx);
+    }
+
     #[cfg(test)]
     #[must_use]
     pub fn block_view(&self, id: BlockId) -> Option<&Entity<BlockView>> {
         self.blocks.get(&id)
     }
+}
+
+/// The children of the block at `path` (empty slice semantics: `path` must
+/// be valid, which `Outline::path_to` guarantees for a live id).
+fn children_at<'a>(roots: &'a [Block], path: &[usize]) -> &'a [Block] {
+    let mut blocks = roots;
+    let mut node: Option<&Block> = None;
+    for &i in path {
+        node = Some(&blocks[i]);
+        blocks = &blocks[i].children;
+    }
+    node.map_or(&[], |b| &b.children)
 }
 
 fn flatten_visible(roots: &[Block]) -> Vec<(usize, BlockId)> {
@@ -118,8 +243,36 @@ impl Render for OutlineView {
         self.blocks.retain(|id, _| all_ids.contains(id));
         self.block_subs.retain(|id, _| all_ids.contains(id));
 
+        // The bindings target the `BlockView` key context (see BLOCK_CONTEXT),
+        // but the handlers live here because the ops need the outline-wide
+        // view map and traversal order. Actions dispatched from a focused
+        // block bubble up through this ancestor node.
         let mut root = div()
             .track_focus(&self.focus_handle)
+            .on_action(cx.listener(|this, _: &FocusUp, window, cx| {
+                this.move_focus(-1, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusDown, window, cx| {
+                this.move_focus(1, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &IndentBlock, window, cx| {
+                this.update_focused_block(window, cx, Page::indent_block);
+            }))
+            .on_action(cx.listener(|this, _: &OutdentBlock, window, cx| {
+                this.update_focused_block(window, cx, Page::outdent_block);
+            }))
+            .on_action(cx.listener(|this, _: &MoveBlockUp, window, cx| {
+                this.update_focused_block(window, cx, Page::move_block_up);
+            }))
+            .on_action(cx.listener(|this, _: &MoveBlockDown, window, cx| {
+                this.update_focused_block(window, cx, Page::move_block_down);
+            }))
+            .on_action(cx.listener(|this, _: &ToggleCollapse, window, cx| {
+                this.update_focused_block(window, cx, Page::toggle_collapse);
+            }))
+            .on_action(cx.listener(|this, _: &DeleteBackward, window, cx| {
+                this.delete_backward(window, cx);
+            }))
             .flex()
             .flex_col()
             .gap_1();
@@ -167,6 +320,7 @@ mod tests {
         let (ov, vcx) = cx.add_window_view(move |_window, cx| {
             text_input::bind_keys(cx);
             crate::block_view::bind_keys(cx);
+            super::bind_keys(cx);
             let page = cx.new(|cx| Page::new("foo".into(), &body, cx));
             cx.set_global(TestPage(page));
             OutlineView::new(cx.global::<TestPage>().0.clone(), cx)
@@ -384,6 +538,228 @@ mod tests {
             assert!(
                 bv.read(cx).focus_handle(cx).is_focused(window),
                 "first block holds focus in viewing mode",
+            );
+        });
+    }
+
+    /// Focuses the block with `id` (mounting its view if needed) and settles.
+    fn focus_block(cx: &mut VisualTestContext, ov: &Entity<OutlineView>, id: BlockId) {
+        cx.update(|window, cx| {
+            let bv = ov.update(cx, |o, cx| o.get_or_create(id, window, cx));
+            window.focus(&bv.focus_handle(cx), cx);
+        });
+        cx.run_until_parked();
+    }
+
+    fn focused_id(cx: &mut VisualTestContext, ov: &Entity<OutlineView>) -> Option<BlockId> {
+        cx.update(|window, cx| ov.read(cx).focused_block_id(window, cx))
+    }
+
+    // ── #44: keyboard navigation and block operations ──────────────────
+
+    #[gpui::test]
+    fn up_down_move_focus_through_visible_blocks(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n- b\n");
+        let (a, b) = cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            (outline.roots[0].id, outline.roots[1].id)
+        });
+
+        focus_block(cx, &ov, a);
+
+        cx.simulate_keystrokes("down");
+        cx.run_until_parked();
+        assert_eq!(focused_id(cx, &ov), Some(b), "down moves to next block");
+
+        cx.simulate_keystrokes("down");
+        cx.run_until_parked();
+        assert_eq!(
+            focused_id(cx, &ov),
+            Some(b),
+            "down clamps at the last block"
+        );
+
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+        assert_eq!(focused_id(cx, &ov), Some(a), "up moves back to the first");
+
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+        assert_eq!(focused_id(cx, &ov), Some(a), "up clamps at the first block");
+    }
+
+    #[gpui::test]
+    fn tab_indents_focused_block(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n- b\n");
+        let b = cx.read(|cx| page.read(cx).outline().roots[1].id);
+
+        focus_block(cx, &ov, b);
+        cx.simulate_keystrokes("tab");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            assert_eq!(outline.roots.len(), 1, "b indented under a");
+            assert_eq!(outline.roots[0].children[0].text, "b");
+            assert!(page.read(cx).dirty(), "structural edit dirties the page");
+        });
+        assert_eq!(focused_id(cx, &ov), Some(b), "focus stays on the block");
+    }
+
+    #[gpui::test]
+    fn shift_tab_outdents_focused_block(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n  - b\n");
+        let b = cx.read(|cx| page.read(cx).outline().roots[0].children[0].id);
+
+        focus_block(cx, &ov, b);
+        cx.simulate_keystrokes("shift-tab");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            assert_eq!(outline.roots.len(), 2, "b raised to root level");
+            assert_eq!(outline.roots[1].text, "b");
+        });
+    }
+
+    #[gpui::test]
+    fn alt_up_down_move_block_among_siblings(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n- b\n");
+        let a = cx.read(|cx| page.read(cx).outline().roots[0].id);
+
+        focus_block(cx, &ov, a);
+        cx.simulate_keystrokes("alt-down");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            assert_eq!(outline.roots[0].text, "b");
+            assert_eq!(outline.roots[1].text, "a");
+        });
+
+        cx.simulate_keystrokes("alt-up");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            assert_eq!(outline.roots[0].text, "a", "alt-up moves it back");
+        });
+    }
+
+    #[gpui::test]
+    fn ctrl_enter_toggles_collapse_without_dirtying(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n  - b\n");
+        let a = cx.read(|cx| page.read(cx).outline().roots[0].id);
+
+        focus_block(cx, &ov, a);
+        cx.simulate_keystrokes("ctrl-enter");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            assert!(outline.roots[0].collapsed, "a collapsed");
+            assert_eq!(
+                flatten_visible(&outline.roots).len(),
+                1,
+                "collapsed child hidden from the visible order",
+            );
+            assert!(
+                !page.read(cx).dirty(),
+                "collapse is view-only state — must not dirty the page",
+            );
+        });
+
+        cx.simulate_keystrokes("ctrl-enter");
+        cx.run_until_parked();
+        cx.read(|cx| {
+            assert!(!page.read(cx).outline().roots[0].collapsed, "re-expanded");
+        });
+    }
+
+    #[gpui::test]
+    fn backspace_on_empty_block_deletes_and_focuses_previous(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n- b\n");
+        let (a, b) = cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            (outline.roots[0].id, outline.roots[1].id)
+        });
+        cx.update(|_, cx| page.update(cx, |p, cx| p.set_block_text(b, "", cx)));
+
+        focus_block(cx, &ov, b);
+        cx.simulate_keystrokes("backspace");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            assert_eq!(outline.roots.len(), 1, "empty block deleted");
+            assert_eq!(outline.roots[0].text, "a");
+        });
+        assert_eq!(focused_id(cx, &ov), Some(a), "previous block takes focus");
+    }
+
+    #[gpui::test]
+    fn backspace_on_non_empty_block_does_not_delete(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n- b\n");
+        let b = cx.read(|cx| page.read(cx).outline().roots[1].id);
+
+        focus_block(cx, &ov, b);
+        cx.simulate_keystrokes("backspace");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            assert_eq!(
+                page.read(cx).outline().roots.len(),
+                2,
+                "non-empty block must not be deleted",
+            );
+        });
+    }
+
+    /// An empty block that still has children is not deleted — backspace
+    /// must never silently drop a subtree.
+    #[gpui::test]
+    fn backspace_on_empty_block_with_children_is_noop(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n- p\n  - c\n");
+        let p = cx.read(|cx| page.read(cx).outline().roots[1].id);
+        cx.update(|_, cx| page.update(cx, |pg, cx| pg.set_block_text(p, "", cx)));
+
+        focus_block(cx, &ov, p);
+        cx.simulate_keystrokes("backspace");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            assert_eq!(outline.roots.len(), 2, "parent block survives");
+            assert_eq!(outline.roots[1].children.len(), 1, "child survives");
+        });
+    }
+
+    /// The `!editing` guard in `BLOCK_CONTEXT`: while a block's `TextInput` is
+    /// focused, outline keys (which the input does not bind) must not leak
+    /// into outline ops through the wrapper's ancestor key context.
+    #[gpui::test]
+    fn outline_keys_do_not_fire_while_editing(cx: &mut TestAppContext) {
+        let (page, ov, cx) = mount(cx, "- a\n- b\n");
+        let b = cx.read(|cx| page.read(cx).outline().roots[1].id);
+
+        focus_block(cx, &ov, b);
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        cx.read(|cx| {
+            let bv = ov.read(cx).block_view(b).expect("b mounted").clone();
+            assert!(bv.read(cx).is_editing(), "precondition: editing");
+        });
+
+        cx.simulate_keystrokes("tab up");
+        cx.run_until_parked();
+
+        cx.read(|cx| {
+            let outline = page.read(cx).outline();
+            assert_eq!(outline.roots.len(), 2, "tab mid-edit must not indent");
+            let bv = ov.read(cx).block_view(b).expect("b mounted").clone();
+            assert!(
+                bv.read(cx).is_editing(),
+                "up mid-edit must not move focus out of the editor",
             );
         });
     }

--- a/src/page.rs
+++ b/src/page.rs
@@ -96,6 +96,55 @@ impl Page {
         Some(new_id)
     }
 
+    /// Applies a structural outline edit. If `op` reports a change, the body
+    /// is reserialized, the page marked dirty, and observers notified.
+    /// Returns whether anything changed.
+    fn apply_outline_edit(
+        &mut self,
+        cx: &mut Context<Self>,
+        op: impl FnOnce(&mut Outline) -> bool,
+    ) -> bool {
+        if !op(&mut self.outline) {
+            return false;
+        }
+        self.body = self.outline.serialize().into();
+        self.dirty = true;
+        cx.notify();
+        true
+    }
+
+    pub fn indent_block(&mut self, id: BlockId, cx: &mut Context<Self>) -> bool {
+        self.apply_outline_edit(cx, |o| o.indent(id))
+    }
+
+    pub fn outdent_block(&mut self, id: BlockId, cx: &mut Context<Self>) -> bool {
+        self.apply_outline_edit(cx, |o| o.outdent(id))
+    }
+
+    pub fn move_block_up(&mut self, id: BlockId, cx: &mut Context<Self>) -> bool {
+        self.apply_outline_edit(cx, |o| o.move_up(id))
+    }
+
+    pub fn move_block_down(&mut self, id: BlockId, cx: &mut Context<Self>) -> bool {
+        self.apply_outline_edit(cx, |o| o.move_down(id))
+    }
+
+    /// Deletes the block (and its subtree) from the outline.
+    pub fn delete_block(&mut self, id: BlockId, cx: &mut Context<Self>) -> bool {
+        self.apply_outline_edit(cx, |o| o.delete(id).is_some())
+    }
+
+    /// Collapse state is view-only — it is not serialized into the body —
+    /// so toggling must re-render but must not dirty the page.
+    pub fn toggle_collapse(&mut self, id: BlockId, cx: &mut Context<Self>) -> bool {
+        if self.outline.toggle_collapse(id) {
+            cx.notify();
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn mark_saved(&mut self, cx: &mut Context<Self>) {
         if self.dirty {
             self.dirty = false;


### PR DESCRIPTION
> **Stacked on #55** (#42's branch). GitHub will retarget this to `main` automatically when #55 merges.

The entire outliner data layer — `Outline::{indent, outdent, move_up, move_down, toggle_collapse, delete}` — was implemented and tested but unreachable from the UI. With #42's focused-but-viewing state as the anchor, this wires it all up.

## Bindings (on the focused, non-editing block)

| Key | Action |
|---|---|
| `up` / `down` | move focus across visible blocks (respects collapse, clamps at ends) |
| `enter` | begin editing (from #42) |
| `tab` / `shift-tab` | indent / outdent |
| `alt-up` / `alt-down` | move block among siblings |
| `ctrl/cmd-enter` | toggle collapse |
| `backspace` | delete an empty focused block, focus the previous visible one |

Design notes:

- **`Page` wrappers** (`indent_block`, `outdent_block`, `move_block_up/down`, `delete_block`) mirror `insert_block_after`: reserialize + mark dirty + notify. `toggle_collapse` is the exception — collapse state is not serialized, so it re-renders but deliberately does **not** dirty the page.
- **Context guard:** bindings target `"BlockView && !editing"`. The block wrapper is an ancestor of its `TextInput`, so without the guard, keys the input doesn't bind (up/down/tab…) would leak into outline ops mid-edit. The wrapper stamps `editing` onto its key context while an editor is mounted.
- **Backspace safety:** only an empty **and childless** block is deleted (never silently drops a subtree), and never the last visible block. Deleting the first block focuses the next one instead of the previous.
- Handlers live on `OutlineView` (which owns the view map and traversal order); the collapse modifier routes through the platform-aware `cmd_key()` helper. The shortcuts cheatsheet lists all the new keys.

## Tests

One simulated-keystroke test per binding (`up_down_move_focus_through_visible_blocks`, `tab_indents_focused_block`, `shift_tab_outdents_focused_block`, `alt_up_down_move_block_among_siblings`, `ctrl_enter_toggles_collapse_without_dirtying`, `backspace_on_empty_block_deletes_and_focuses_previous`), plus the issue's "backspace on non-empty block does not delete", the subtree guard, and `outline_keys_do_not_fire_while_editing` for the `!editing` context predicate. 169/169 pass; clippy clean.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)