### PR TITLE
refactor: centralize focus parking and theme tokens

### DIFF
--- a/src/block_render.rs
+++ b/src/block_render.rs
@@ -17,31 +17,9 @@ use gpui::{
 };
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 
-pub mod theme {
-    use gpui::rgb;
-    use gpui::Rgba;
-
-    #[must_use]
-    pub fn fg() -> Rgba {
-        rgb(0xe6e6e6)
-    }
-    #[must_use]
-    pub fn fg_muted() -> Rgba {
-        rgb(0x9a9a9a)
-    }
-    #[must_use]
-    pub fn bg_subtle() -> Rgba {
-        rgb(0x2a2a2a)
-    }
-    #[must_use]
-    pub fn accent() -> Rgba {
-        rgb(0x66b2ff)
-    }
-    #[must_use]
-    pub fn code_bg() -> Rgba {
-        rgb(0x1e1e1e)
-    }
-}
+/// Compatibility re-export for existing block-render callers. New code should
+/// import [`crate::theme`] directly.
+pub use crate::theme;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Style {

--- a/src/block_view.rs
+++ b/src/block_view.rs
@@ -252,7 +252,7 @@ impl Render for BlockView {
         let ring = if focused {
             theme::accent()
         } else {
-            gpui::rgba(0x0000_0000)
+            theme::transparent()
         };
 
         // Drive the edit transition directly from the click. `begin_editing`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,5 @@ pub mod registry;
 pub mod store;
 pub mod tags;
 pub mod text_input;
+pub mod theme;
 pub mod window_frame;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unreadable_literal)]
 
 use gpui::{
-    actions, div, prelude::*, px, rgb, size, App, AppContext, Bounds, Context, ElementId, Entity,
+    actions, div, prelude::*, px, size, App, AppContext, Bounds, Context, ElementId, Entity,
     FocusHandle, Focusable, IntoElement, KeyBinding, MouseButton, ParentElement, Render,
     SharedString, Styled, Subscription, Window, WindowBounds, WindowOptions,
 };
@@ -18,6 +18,7 @@ use gpui_notes::registry::{
 use gpui_notes::store::NotesStore;
 use gpui_notes::tags::{self, OpenTag, TagIndex, TagSource};
 use gpui_notes::text_input;
+use gpui_notes::theme;
 use gpui_notes::window_frame::WindowFrame;
 use gpui_platform::application;
 
@@ -110,6 +111,7 @@ struct RootView {
     _current_observer: Subscription,
     _tag_observer: Subscription,
     _error_observer: Subscription,
+    debug_hud: bool,
 }
 
 impl RootView {
@@ -123,6 +125,7 @@ impl RootView {
             _current_observer: current_observer,
             _tag_observer: tag_observer,
             _error_observer: error_observer,
+            debug_hud: std::env::var("GPUI_NOTES_DEBUG_HUD").is_ok_and(|value| value == "1"),
         }
     }
 
@@ -131,16 +134,26 @@ impl RootView {
         &self.overlay
     }
 
-    /// Focuses the first block of the current page, or the root view if no
-    /// page is open. Call after any action that swaps `CurrentPage`, otherwise
-    /// the window is left without a focused block and keystrokes fall through
-    /// until the user clicks one.
-    fn focus_current(&self, window: &mut Window, cx: &mut App) {
-        if let Some(page) = cx.global::<CurrentPage>().get().cloned() {
-            let view = page.read(cx).view().clone();
-            view.update(cx, |v, cx| v.focus_first_block(window, cx));
-        } else {
-            window.focus(&self.focus_handle.clone(), cx);
+    /// Parks focus after a root-level state transition. This is the single
+    /// owner of the policy: the target is derived only from the active overlay
+    /// and current page, so an action cannot accidentally leave the `RootView`
+    /// key context without a focused descendant.
+    fn park_focus(&self, window: &mut Window, cx: &mut App) {
+        match &self.overlay {
+            OverlayMode::PagePicker { entity, .. } => {
+                entity.update(cx, |picker, cx| picker.focus_input(window, cx));
+            }
+            OverlayMode::TagResults(_) | OverlayMode::ShortcutsHelp => {
+                window.focus(&self.focus_handle, cx);
+            }
+            OverlayMode::None => {
+                if let Some(page) = cx.global::<CurrentPage>().get().cloned() {
+                    let view = page.read(cx).view().clone();
+                    view.update(cx, |view, cx| view.focus_first_block(window, cx));
+                } else {
+                    window.focus(&self.focus_handle, cx);
+                }
+            }
         }
     }
 
@@ -161,7 +174,7 @@ impl RootView {
             return;
         }
         self.overlay = OverlayMode::None;
-        self.focus_current(window, cx);
+        self.park_focus(window, cx);
     }
 
     fn next_page(&mut self, _: &NextPage, window: &mut Window, cx: &mut Context<Self>) {
@@ -184,15 +197,13 @@ impl RootView {
             return;
         }
         self.overlay = OverlayMode::None;
-        self.focus_current(window, cx);
+        self.park_focus(window, cx);
     }
 
     fn open_tag(&mut self, action: &OpenTag, window: &mut Window, cx: &mut Context<Self>) {
         Self::reindex_current_page(cx);
         self.overlay = OverlayMode::TagResults(action.name.clone());
-        // Park focus on RootView so Escape dispatches `CloseTagView` instead of
-        // a stale TextInput::Cancel from the previously-edited block.
-        window.focus(&self.focus_handle, cx);
+        self.park_focus(window, cx);
         cx.notify();
     }
 
@@ -205,7 +216,7 @@ impl RootView {
             return;
         }
         self.overlay = OverlayMode::None;
-        self.focus_current(window, cx);
+        self.park_focus(window, cx);
         cx.notify();
     }
 
@@ -217,12 +228,10 @@ impl RootView {
     ) {
         if matches!(self.overlay, OverlayMode::ShortcutsHelp) {
             self.overlay = OverlayMode::None;
-            self.focus_current(window, cx);
+            self.park_focus(window, cx);
         } else {
             self.overlay = OverlayMode::ShortcutsHelp;
-            // Park focus on the root so Escape lands on `CloseTagView` (which
-            // also dismisses the overlay) instead of a stale TextInput.
-            window.focus(&self.focus_handle, cx);
+            self.park_focus(window, cx);
         }
         cx.notify();
     }
@@ -237,7 +246,7 @@ impl RootView {
             .flex_row()
             .items_center()
             .gap_2()
-            .text_color(rgb(0xcccccc))
+            .text_color(theme::header_fg())
             .text_size(px(14.))
             .child(div().flex_1().child(header_text))
             .child(
@@ -246,8 +255,12 @@ impl RootView {
                     .px_2()
                     .rounded_sm()
                     .cursor_pointer()
-                    .text_color(rgb(0x888888))
-                    .hover(|style| style.bg(rgb(0x2a2a2a)).text_color(rgb(0xdddddd)))
+                    .text_color(theme::control_fg())
+                    .hover(|style| {
+                        style
+                            .bg(theme::row_hover())
+                            .text_color(theme::control_hover_fg())
+                    })
                     .child("?")
                     .on_mouse_down(
                         MouseButton::Left,
@@ -263,8 +276,12 @@ impl RootView {
                     .px_2()
                     .rounded_sm()
                     .cursor_pointer()
-                    .text_color(rgb(0x888888))
-                    .hover(|style| style.bg(rgb(0x2a2a2a)).text_color(rgb(0xdddddd)))
+                    .text_color(theme::control_fg())
+                    .hover(|style| {
+                        style
+                            .bg(theme::row_hover())
+                            .text_color(theme::control_hover_fg())
+                    })
                     .child("× close")
                     .on_mouse_down(
                         MouseButton::Left,
@@ -290,12 +307,12 @@ impl RootView {
             .py_1()
             .rounded_sm()
             .cursor_pointer()
-            .bg(rgb(0x3a2222))
-            .text_color(rgb(0xff9999))
+            .bg(theme::error_bg())
+            .text_color(theme::error_fg())
             .text_size(px(13.))
-            .hover(|style| style.bg(rgb(0x4a2a2a)))
+            .hover(|style| style.bg(theme::error_hover_bg()))
             .child(div().flex_1().child(SharedString::from(message)))
-            .child(div().text_color(rgb(0x888888)).child("× dismiss"))
+            .child(div().text_color(theme::control_fg()).child("× dismiss"))
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|_, _, _, cx| errors::dismiss(cx)),
@@ -318,13 +335,13 @@ impl RootView {
                             .px_2()
                             .py_0p5()
                             .rounded_sm()
-                            .bg(rgb(0x2a2a2a))
-                            .text_color(rgb(0xffffff))
+                            .bg(theme::bg_subtle())
+                            .text_color(theme::row_selected_fg())
                             .child(SharedString::from(keys)),
                     )
                     .child(
                         div()
-                            .text_color(rgb(0xcccccc))
+                            .text_color(theme::header_fg())
                             .child(SharedString::from(label)),
                     ),
             );
@@ -334,15 +351,15 @@ impl RootView {
             .flex()
             .flex_col()
             .gap_2()
-            .bg(rgb(0x141414))
+            .bg(theme::overlay_bg())
             .border_1()
-            .border_color(rgb(0x3a3a3a))
+            .border_color(theme::overlay_border())
             .rounded_md()
             .p_4()
             .min_w(px(360.0))
             .child(
                 div()
-                    .text_color(rgb(0xeeeeee))
+                    .text_color(theme::overlay_title_fg())
                     .text_size(px(14.))
                     .child("Keyboard shortcuts"),
             )
@@ -366,7 +383,7 @@ impl RootView {
                 return;
             }
         };
-        let picker = cx.new(|cx| PagePicker::new(entries, window, cx));
+        let picker = cx.new(|cx| PagePicker::new(entries, cx));
         let sub = cx.subscribe_in(
             &picker,
             window,
@@ -383,6 +400,7 @@ impl RootView {
             entity: picker,
             _sub: sub,
         };
+        self.park_focus(window, cx);
         cx.notify();
     }
 
@@ -415,7 +433,7 @@ impl RootView {
 
     fn close_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.overlay = OverlayMode::None;
-        self.focus_current(window, cx);
+        self.park_focus(window, cx);
         cx.notify();
     }
 
@@ -438,7 +456,7 @@ impl RootView {
             return;
         }
         self.overlay = OverlayMode::None;
-        self.focus_current(window, cx);
+        self.park_focus(window, cx);
         cx.notify();
     }
 
@@ -447,7 +465,7 @@ impl RootView {
         if hits.is_empty() {
             return div()
                 .flex_1()
-                .text_color(rgb(0x999999))
+                .text_color(theme::empty_state_fg())
                 .child("No blocks found.")
                 .into_any_element();
         }
@@ -468,8 +486,8 @@ impl RootView {
                     .px_2()
                     .py_1()
                     .min_h(px(28.0))
-                    .text_color(rgb(0xdddddd))
-                    .hover(|style| style.bg(rgb(0x2a2a2a)))
+                    .text_color(theme::control_hover_fg())
+                    .hover(|style| style.bg(theme::row_hover()))
                     .child(format!("{label}: {preview}"))
                     .on_click(cx.listener(move |this, _, window, cx| {
                         this.open_tag_hit(&source, window, cx);
@@ -477,6 +495,36 @@ impl RootView {
             );
         }
         list.into_any_element()
+    }
+
+    fn debug_hud_text(&self, window: &Window, cx: &App) -> String {
+        let (focus_target, block_mode) = match &self.overlay {
+            OverlayMode::PagePicker { .. } => ("page picker input", "not applicable"),
+            OverlayMode::TagResults(_) | OverlayMode::ShortcutsHelp => ("root", "not applicable"),
+            OverlayMode::None => {
+                let Some(page) = cx.global::<CurrentPage>().get().cloned() else {
+                    return "focus: root · block: no page".to_string();
+                };
+                let view = page.read(cx).view().clone();
+                view.read(cx).debug_focus_status(window, cx)
+            }
+        };
+        format!("focus: {focus_target} · block: {block_mode}")
+    }
+
+    fn render_debug_hud(text: String) -> gpui::AnyElement {
+        div()
+            .id(ElementId::Name(SharedString::from("debug-focus-hud")))
+            .px_2()
+            .py_1()
+            .rounded_sm()
+            .bg(theme::overlay_bg())
+            .border_1()
+            .border_color(theme::overlay_border())
+            .text_color(theme::fg_muted())
+            .text_size(px(12.))
+            .child(text)
+            .into_any_element()
     }
 }
 
@@ -487,7 +535,7 @@ impl Focusable for RootView {
 }
 
 impl Render for RootView {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let current: Option<Entity<Page>> = cx.global::<CurrentPage>().get().cloned();
 
         let mut root = div()
@@ -504,13 +552,13 @@ impl Render for RootView {
             .flex()
             .flex_col()
             .size_full()
-            .bg(rgb(0x1e1e1e))
+            .bg(theme::window_bg())
             .p_4()
             .gap_2();
         root.text_style().font_fallbacks = Some(text_input::emoji_font_fallbacks());
 
         let Some(page) = current else {
-            return root.child(div().text_color(rgb(0xcccccc)).child("No page open."));
+            return root.child(div().text_color(theme::header_fg()).child("No page open."));
         };
 
         let (name, dirty, view) = {
@@ -527,6 +575,10 @@ impl Render for RootView {
         };
 
         let mut root = root.child(Self::render_header(header_text, active_tag.is_some(), cx));
+
+        if self.debug_hud {
+            root = root.child(Self::render_debug_hud(self.debug_hud_text(window, cx)));
+        }
 
         let error_message = cx
             .global::<LastError>()
@@ -605,7 +657,7 @@ fn main() {
             },
             |window, cx| {
                 let root = cx.new(RootView::new);
-                root.update(cx, |view, cx| view.focus_current(window, cx));
+                root.update(cx, |view, cx| view.park_focus(window, cx));
                 cx.activate(true);
                 cx.new(|_| WindowFrame::new("GPUI Notes", root))
             },
@@ -651,10 +703,23 @@ mod tests {
         });
         vcx.update(|window, cx| {
             window.activate_window();
-            root.update(cx, |view, cx| view.focus_current(window, cx));
+            root.update(cx, |view, cx| view.park_focus(window, cx));
         });
         vcx.run_until_parked();
         (root, vcx)
+    }
+
+    /// Assert the actual GPUI focus path still includes the element that
+    /// provides the `RootView` key context. This catches dead-keymap
+    /// regressions even when the immediately preceding action looked correct.
+    fn assert_root_in_focus_path(cx: &mut VisualTestContext, root: &Entity<RootView>) {
+        cx.update(|window, cx| {
+            let root_focus = root.read(cx).focus_handle(cx);
+            assert!(
+                root_focus.contains_focused(window, cx),
+                "focused element must remain beneath RootView",
+            );
+        });
     }
 
     #[gpui::test]
@@ -793,6 +858,7 @@ mod tests {
 
         cx.simulate_keystrokes("ctrl-o");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
 
         cx.read(|cx| {
             assert!(
@@ -832,6 +898,7 @@ mod tests {
 
         cx.simulate_keystrokes("ctrl-o");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
 
         assert!(cx.read(|cx| root.read(cx).overlay().picker().is_some()));
     }
@@ -844,10 +911,12 @@ mod tests {
 
         cx.simulate_keystrokes("ctrl-o");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
         assert!(cx.read(|cx| root.read(cx).overlay().picker().is_some()));
 
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
 
         assert!(cx.read(|cx| root.read(cx).overlay().is_none()));
     }
@@ -860,6 +929,7 @@ mod tests {
 
         cx.simulate_keystrokes("ctrl-/");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
 
         assert!(cx.read(|cx| root.read(cx).overlay().is_shortcuts()));
     }
@@ -875,10 +945,12 @@ mod tests {
 
         cx.simulate_keystrokes("ctrl-/");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
         assert!(cx.read(|cx| root.read(cx).overlay().is_shortcuts()));
 
         cx.simulate_keystrokes("ctrl-/");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
 
         assert!(cx.read(|cx| root.read(cx).overlay().is_none()));
     }
@@ -904,6 +976,7 @@ mod tests {
             });
         });
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
 
         assert_eq!(
             cx.read(|cx| root.read(cx).overlay().tag_name().map(ToString::to_string)),
@@ -930,10 +1003,12 @@ mod tests {
             });
         });
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
         assert!(cx.read(|cx| root.read(cx).overlay().tag_name().is_some()));
 
         cx.simulate_keystrokes("ctrl-p");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
 
         cx.read(|cx| {
             assert!(root.read(cx).overlay().is_none(), "tag view cleared");
@@ -951,10 +1026,12 @@ mod tests {
 
         cx.simulate_keystrokes("ctrl-/");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
         assert!(cx.read(|cx| root.read(cx).overlay().is_shortcuts()));
 
         cx.simulate_keystrokes("ctrl-.");
         cx.run_until_parked();
+        assert_root_in_focus_path(cx, &root);
 
         cx.read(|cx| {
             assert!(root.read(cx).overlay().is_none(), "shortcuts cleared");

--- a/src/outline_view.rs
+++ b/src/outline_view.rs
@@ -78,14 +78,38 @@ impl OutlineView {
     }
 
     /// Focus the first root block in the outline, creating its `BlockView` if
-    /// needed. No-op for an empty outline.
+    /// needed. An empty outline falls back to this view's own focus handle so
+    /// the enclosing `RootView` remains in the key dispatch path.
     pub fn focus_first_block(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(first_id) = self.page.read(cx).outline().first_block_id() else {
+            window.focus(&self.focus_handle, cx);
             return;
         };
         let bv = self.get_or_create(first_id, window, cx);
         let handle = bv.focus_handle(cx);
         window.focus(&handle, cx);
+    }
+
+    /// Describes the active page-body focus target for the optional root debug
+    /// HUD. `contains_focused` follows the real GPUI focus path, so an active
+    /// text input is correctly reported as belonging to its block.
+    #[must_use]
+    pub fn debug_focus_status(&self, window: &Window, cx: &App) -> (&'static str, &'static str) {
+        for block in self.blocks.values() {
+            let block = block.read(cx);
+            if block.focus_handle(cx).contains_focused(window, cx) {
+                return if block.is_editing() {
+                    ("block input", "editing")
+                } else {
+                    ("block", "viewing")
+                };
+            }
+        }
+        if self.focus_handle.is_focused(window) {
+            ("outline", "no block")
+        } else {
+            ("none", "no block")
+        }
     }
 
     fn get_or_create(

--- a/src/page_picker.rs
+++ b/src/page_picker.rs
@@ -6,12 +6,13 @@
 
 use chrono::NaiveDate;
 use gpui::{
-    actions, div, prelude::*, px, rgb, App, AppContext, Context, ElementId, Entity, EventEmitter,
+    actions, div, prelude::*, px, App, AppContext, Context, ElementId, Entity, EventEmitter,
     FocusHandle, Focusable, IntoElement, KeyBinding, ParentElement, Render, SharedString, Styled,
     Subscription, Window,
 };
 
 use crate::text_input::{TextInput, TextInputEvent};
+use crate::theme;
 
 actions!(page_picker, [SelectUp, SelectDown]);
 
@@ -79,10 +80,8 @@ pub struct PagePicker {
 }
 
 impl PagePicker {
-    pub fn new(entries: Vec<PageEntry>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+    pub fn new(entries: Vec<PageEntry>, cx: &mut Context<Self>) -> Self {
         let input = cx.new(|cx| TextInput::new(cx, "Type to filter…"));
-        let input_focus = input.focus_handle(cx);
-        window.focus(&input_focus, cx);
 
         let sub = cx.subscribe(&input, |this, _input, event, cx| match event {
             TextInputEvent::Changed(query) => {
@@ -108,6 +107,13 @@ impl PagePicker {
             focus_handle: cx.focus_handle(),
             _input_sub: sub,
         }
+    }
+
+    /// Give the filter input focus. The parent `RootView` owns when this is
+    /// called so overlay transitions have a single focus-parking policy.
+    pub fn focus_input(&self, window: &mut Window, cx: &mut App) {
+        let input_focus = self.input.focus_handle(cx);
+        window.focus(&input_focus, cx);
     }
 
     fn recompute_filter(&mut self, query: &str) {
@@ -215,7 +221,7 @@ impl Render for PagePicker {
                 div()
                     .px_2()
                     .py_1()
-                    .text_color(rgb(0x888888))
+                    .text_color(theme::control_fg())
                     .child("No matches."),
             );
         } else {
@@ -227,9 +233,9 @@ impl Render for PagePicker {
                 let is_selected = row == self.selected;
                 let entry_for_click = entry.clone();
                 let (bg_color, fg_color) = if is_selected {
-                    (rgb(0x3a3a3a), rgb(0xffffff))
+                    (theme::row_selected(), theme::row_selected_fg())
                 } else {
-                    (rgb(0x222222), rgb(0xcccccc))
+                    (theme::row_bg(), theme::header_fg())
                 };
                 list = list.child(
                     div()
@@ -258,9 +264,9 @@ impl Render for PagePicker {
             .flex()
             .flex_col()
             .gap_2()
-            .bg(rgb(0x141414))
+            .bg(theme::overlay_bg())
             .border_1()
-            .border_color(rgb(0x3a3a3a))
+            .border_color(theme::overlay_border())
             .rounded_md()
             .p_3()
             .min_w(px(360.0))
@@ -288,10 +294,10 @@ mod tests {
 
     #[gpui::test]
     fn substring_filter_narrows_list(cx: &mut TestAppContext) {
-        let (picker, vcx) = cx.add_window_view(|window, cx| {
+        let (picker, vcx) = cx.add_window_view(|_window, cx| {
             text_input::bind_keys(cx);
             bind_keys(cx);
-            PagePicker::new(entries(), window, cx)
+            PagePicker::new(entries(), cx)
         });
         vcx.run_until_parked();
 
@@ -313,12 +319,16 @@ mod tests {
 
     #[gpui::test]
     fn enter_emits_selected(cx: &mut TestAppContext) {
-        let (picker, vcx) = cx.add_window_view(|window, cx| {
+        let (picker, vcx) = cx.add_window_view(|_window, cx| {
             text_input::bind_keys(cx);
             bind_keys(cx);
-            PagePicker::new(entries(), window, cx)
+            PagePicker::new(entries(), cx)
         });
-        vcx.update(|window, _| window.activate_window());
+        vcx.update(|window, cx| {
+            window.activate_window();
+            let input_focus = picker.read(cx).input().focus_handle(cx);
+            window.focus(&input_focus, cx);
+        });
         vcx.run_until_parked();
 
         let recorder = vcx.update(|_, cx| {
@@ -357,12 +367,16 @@ mod tests {
 
     #[gpui::test]
     fn down_arrow_moves_selection(cx: &mut TestAppContext) {
-        let (picker, vcx) = cx.add_window_view(|window, cx| {
+        let (picker, vcx) = cx.add_window_view(|_window, cx| {
             text_input::bind_keys(cx);
             bind_keys(cx);
-            PagePicker::new(entries(), window, cx)
+            PagePicker::new(entries(), cx)
         });
-        vcx.update(|window, _| window.activate_window());
+        vcx.update(|window, cx| {
+            window.activate_window();
+            let input_focus = picker.read(cx).input().focus_handle(cx);
+            window.focus(&input_focus, cx);
+        });
         vcx.run_until_parked();
 
         vcx.simulate_keystrokes("down");
@@ -390,12 +404,16 @@ mod tests {
     // ────────────────────────────────────────────────────────────────────
 
     fn mount_picker(cx: &mut TestAppContext) -> (Entity<PagePicker>, &mut gpui::VisualTestContext) {
-        let (picker, vcx) = cx.add_window_view(|window, cx| {
+        let (picker, vcx) = cx.add_window_view(|_window, cx| {
             text_input::bind_keys(cx);
             bind_keys(cx);
-            PagePicker::new(entries(), window, cx)
+            PagePicker::new(entries(), cx)
         });
-        vcx.update(|window, _| window.activate_window());
+        vcx.update(|window, cx| {
+            window.activate_window();
+            let input_focus = picker.read(cx).input().focus_handle(cx);
+            window.focus(&input_focus, cx);
+        });
         vcx.run_until_parked();
         (picker, vcx)
     }

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -6,13 +6,14 @@ use std::ops::Range;
 
 use gpui::FontFallbacks;
 use gpui::{
-    actions, div, fill, hsla, point, prelude::*, px, relative, rgb, rgba, size, white, App, Bounds,
-    ClipboardItem, Context, CursorStyle, ElementId, ElementInputHandler, Entity,
-    EntityInputHandler, EventEmitter, FocusHandle, Focusable, GlobalElementId, InspectorElementId,
-    KeyBinding, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,
-    Pixels, Point, ShapedLine, SharedString, Style, TextAlign, TextRun, UTF16Selection,
-    UnderlineStyle, Window,
+    actions, div, fill, point, prelude::*, px, relative, size, App, Bounds, ClipboardItem, Context,
+    CursorStyle, ElementId, ElementInputHandler, Entity, EntityInputHandler, EventEmitter,
+    FocusHandle, Focusable, GlobalElementId, InspectorElementId, KeyBinding, LayoutId, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point, ShapedLine,
+    SharedString, Style, TextAlign, TextRun, UTF16Selection, UnderlineStyle, Window,
 };
+
+use crate::theme;
 
 actions!(
     text_input,
@@ -488,7 +489,10 @@ impl Element for TextElement {
         let style = window.text_style();
 
         let (display_text, text_color) = if content.is_empty() {
-            (input.placeholder.clone(), hsla(0., 0., 0., 0.2))
+            (
+                input.placeholder.clone(),
+                theme::input_placeholder_fg().into(),
+            )
         } else {
             (content, style.color)
         };
@@ -547,7 +551,7 @@ impl Element for TextElement {
                         point(bounds.left() + cursor_pos, bounds.top()),
                         size(px(2.), bounds.bottom() - bounds.top()),
                     ),
-                    gpui::blue(),
+                    theme::input_cursor(),
                 )),
             )
         } else {
@@ -563,7 +567,7 @@ impl Element for TextElement {
                             bounds.bottom(),
                         ),
                     ),
-                    rgba(0x3311ff30),
+                    theme::input_selection(),
                 )),
                 None,
             )
@@ -644,7 +648,8 @@ impl Render for TextInput {
             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_mouse_move(cx.listener(Self::on_mouse_move))
-            .bg(rgb(0xeeeeee))
+            .bg(theme::input_outer_bg())
+            .text_color(theme::input_fg())
             .line_height(px(28.))
             .text_size(px(16.))
             .child(
@@ -652,7 +657,7 @@ impl Render for TextInput {
                     .h(px(28. + 4. * 2.))
                     .w_full()
                     .p(px(4.))
-                    .bg(white())
+                    .bg(theme::input_bg())
                     .child(TextElement { input: cx.entity() }),
             )
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,147 @@
+//! Application-wide color tokens.
+//!
+//! Keep visual decisions here so the dark theme can evolve without hunting
+//! through view implementations. Callers use semantic names rather than raw
+//! RGB values.
+
+use gpui::{rgb, rgba, Rgba};
+
+#[must_use]
+pub fn window_bg() -> Rgba {
+    rgb(0x1e1e1e)
+}
+
+#[must_use]
+pub fn overlay_bg() -> Rgba {
+    rgb(0x141414)
+}
+
+#[must_use]
+pub fn overlay_border() -> Rgba {
+    rgb(0x3a3a3a)
+}
+
+#[must_use]
+pub fn fg() -> Rgba {
+    rgb(0xe6e6e6)
+}
+
+#[must_use]
+pub fn fg_muted() -> Rgba {
+    rgb(0x9a9a9a)
+}
+
+#[must_use]
+pub fn header_fg() -> Rgba {
+    rgb(0xcccccc)
+}
+
+#[must_use]
+pub fn chrome_fg() -> Rgba {
+    rgb(0xaaaaaa)
+}
+
+#[must_use]
+pub fn control_fg() -> Rgba {
+    rgb(0x888888)
+}
+
+#[must_use]
+pub fn control_hover_fg() -> Rgba {
+    rgb(0xdddddd)
+}
+
+#[must_use]
+pub fn overlay_title_fg() -> Rgba {
+    rgb(0xeeeeee)
+}
+
+#[must_use]
+pub fn empty_state_fg() -> Rgba {
+    rgb(0x999999)
+}
+
+#[must_use]
+pub fn bg_subtle() -> Rgba {
+    rgb(0x2a2a2a)
+}
+
+#[must_use]
+pub fn row_bg() -> Rgba {
+    rgb(0x222222)
+}
+
+#[must_use]
+pub fn row_hover() -> Rgba {
+    bg_subtle()
+}
+
+#[must_use]
+pub fn row_selected() -> Rgba {
+    overlay_border()
+}
+
+#[must_use]
+pub fn row_selected_fg() -> Rgba {
+    rgb(0xffffff)
+}
+
+#[must_use]
+pub fn accent() -> Rgba {
+    rgb(0x66b2ff)
+}
+
+#[must_use]
+pub fn code_bg() -> Rgba {
+    window_bg()
+}
+
+#[must_use]
+pub fn input_outer_bg() -> Rgba {
+    bg_subtle()
+}
+
+#[must_use]
+pub fn input_bg() -> Rgba {
+    row_bg()
+}
+
+#[must_use]
+pub fn input_fg() -> Rgba {
+    fg()
+}
+
+#[must_use]
+pub fn input_placeholder_fg() -> Rgba {
+    fg_muted()
+}
+
+#[must_use]
+pub fn input_cursor() -> Rgba {
+    accent()
+}
+
+#[must_use]
+pub fn input_selection() -> Rgba {
+    rgba(0x66b2_ff66)
+}
+
+#[must_use]
+pub fn error_bg() -> Rgba {
+    rgb(0x3a2222)
+}
+
+#[must_use]
+pub fn error_hover_bg() -> Rgba {
+    rgb(0x4a2a2a)
+}
+
+#[must_use]
+pub fn error_fg() -> Rgba {
+    rgb(0xff9999)
+}
+
+#[must_use]
+pub fn transparent() -> Rgba {
+    rgba(0x0000_0000)
+}

--- a/src/window_frame.rs
+++ b/src/window_frame.rs
@@ -9,10 +9,12 @@
 //! `crates/gpui/examples/window_shadow.rs` at the pinned rev.
 
 use gpui::{
-    canvas, div, point, prelude::*, px, rgb, Bounds, Context, CursorStyle, Decorations, Entity,
+    canvas, div, point, prelude::*, px, Bounds, Context, CursorStyle, Decorations, Entity,
     HitboxBehavior, IntoElement, MouseButton, MouseMoveEvent, ParentElement, Pixels, Point, Render,
     ResizeEdge, SharedString, Size, Styled, Window,
 };
+
+use crate::theme;
 
 /// Thickness of the resize hit zone along each edge.
 const EDGE: Pixels = px(6.0);
@@ -101,8 +103,8 @@ fn titlebar(title: SharedString) -> impl IntoElement {
         .flex()
         .items_center()
         .px_3()
-        .bg(rgb(0x2a2a2a))
-        .text_color(rgb(0xaaaaaa))
+        .bg(theme::bg_subtle())
+        .text_color(theme::chrome_fg())
         .child(title)
         .on_mouse_down(MouseButton::Left, |e, window, _| {
             // The top resize band overlaps the title bar. When the click


### PR DESCRIPTION
## Summary
- Centralize root-level focus parking and assert the RootView focus path through overlay transitions.
- Add the opt-in GPUI_NOTES_DEBUG_HUD focus and block-mode display.
- Consolidate color tokens in a shared dark theme and darken TextInput.

## Testing
- just check
- just test

Closes #46
Closes #48